### PR TITLE
Use Supabase upsert for AST finalization

### DIFF
--- a/components/steps/Step6Finalization.tsx
+++ b/components/steps/Step6Finalization.tsx
@@ -1,14 +1,15 @@
 'use client';
 
 import React, { useState, useRef, useCallback, useMemo } from 'react';
-import { 
-  FileText, Database, QrCode, Printer, Mail, Share, Download, 
-  Save, CheckCircle, AlertTriangle, Clock, Shield, Users, 
-  Eye, Globe, Smartphone, Copy, Check, BarChart3, Calendar, 
+import {
+  FileText, Database, QrCode, Printer, Mail, Share, Download,
+  Save, CheckCircle, AlertTriangle, Clock, Shield, Users,
+  Eye, Globe, Smartphone, Copy, Check, BarChart3, Calendar,
   MapPin, Building, User, Search, X, Plus, RefreshCw, Upload,
-  ArrowRight, ArrowLeft, Target, Zap, History, Camera, Archive, 
+  ArrowRight, ArrowLeft, Target, Zap, History, Camera, Archive,
   Send, MessageSquare, Lock, Unlock, Award, Cog, Hash, Share2
 } from 'lucide-react';
+import { supabase } from '@/lib/supabase';
 
 // =================== TYPES DE BASE ===================
 type ShareMethod = 'email' | 'sms' | 'whatsapp' | 'teams' | 'slack';
@@ -1027,17 +1028,16 @@ function Step6Finalization({
           lockout_points: stats.lockoutPoints
         }
       };
-      
+
       console.log('📤 Step6 AST - Données pour Supabase:', supabaseData);
-      
-      // TODO: Intégrer vraie API Supabase
-      // const { data, error } = await supabase
-      //   .from('ast_complete_records')
-      //   .upsert(supabaseData, { onConflict: 'ast_number' });
-      
-      // Simulation délai réseau réaliste
-      await new Promise(resolve => setTimeout(resolve, 2500));
-      
+      const { data, error } = await supabase
+        .from('ast_complete_records')
+        .upsert(supabaseData, { onConflict: 'ast_number' });
+
+      if (error) {
+        throw error;
+      }
+
       // Mise à jour état local avec timestamp de sauvegarde
       const updatedData = {
         ...finalizationData,
@@ -1048,7 +1048,7 @@ function Step6Finalization({
       onDataChange('finalization', updatedData);
       
       showNotificationToast(t.saveSuccess, 'success');
-      console.log('✅ Step6 AST - Sauvegarde Supabase réussie');
+      console.log('✅ Step6 AST - Sauvegarde Supabase réussie', data);
       
     } catch (error) {
       console.error('❌ Step6 AST - Erreur sauvegarde Supabase:', error);


### PR DESCRIPTION
## Summary
- import Supabase client and replace placeholder in finalization step with real `ast_complete_records` upsert
- update state and notifications based on Supabase responses
- drop artificial network delay now that API call is live

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689a92cb7d4883239497f8b34d4466fe