### PR TITLE
Fix permit search query formatting

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -276,12 +276,17 @@ export const searchPermits = async (query: string, province?: ProvinceCode) => {
     .select('*')
 
   if (query.trim()) {
-    queryBuilder = queryBuilder.or(`
-      permit_number.ilike.%${query}%,
-      project_number.ilike.%${query}%,
-      work_location.ilike.%${query}%,
-      contractor.ilike.%${query}%
-    `)
+    const sanitizedQuery = query.trim()
+    const searchExpression = [
+      'permit_number',
+      'project_number',
+      'work_location',
+      'contractor'
+    ]
+      .map((field) => `${field}.ilike.%${sanitizedQuery}%`)
+      .join(',')
+
+    queryBuilder = queryBuilder.or(searchExpression)
   }
 
   if (province) {


### PR DESCRIPTION
## Summary
- sanitize permit search to build Supabase `or` filter without invalid whitespace

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: prompting for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689a917d6f748323864562e5ef5c2438