### PR TITLE
feat: make charts responsive and accessible

### DIFF
--- a/app/[tenant]/dashboard/ManagerDashboard.tsx
+++ b/app/[tenant]/dashboard/ManagerDashboard.tsx
@@ -81,10 +81,10 @@ const getFunctionalData = (isDemo: boolean): DashboardData => {
       nearMiss: 8,
       incidentsTrend: -25,
       incidentsByType: [
-        { type: 'Électrique', count: 3, color: '#ef4444' },
-        { type: 'Chute', count: 2, color: '#f97316' },
-        { type: 'Équipement', count: 2, color: '#eab308' },
-        { type: 'Ergonomique', count: 1, color: '#22c55e' }
+        { type: 'Électrique', count: 3, color: 'var(--color-chart-electrique)' },
+        { type: 'Chute', count: 2, color: 'var(--color-chart-chute)' },
+        { type: 'Équipement', count: 2, color: 'var(--color-chart-equipement)' },
+        { type: 'Ergonomique', count: 1, color: 'var(--color-chart-line)' }
       ],
       
       hoursWorked: 12480,
@@ -117,8 +117,8 @@ const getFunctionalData = (isDemo: boolean): DashboardData => {
       nearMiss: 3,
       incidentsTrend: -100,
       incidentsByType: [
-        { type: 'Électrique', count: 1, color: '#ef4444' },
-        { type: 'Équipement', count: 2, color: '#eab308' }
+        { type: 'Électrique', count: 1, color: 'var(--color-chart-electrique)' },
+        { type: 'Équipement', count: 2, color: 'var(--color-chart-equipement)' }
       ],
       
       hoursWorked: 3240,
@@ -143,14 +143,14 @@ const getFunctionalData = (isDemo: boolean): DashboardData => {
 }
 
 // Composant Graphique Simple
-const SimpleChart = ({ data, type = 'line' }: { data: any[], type?: 'line' | 'bar' | 'pie' }) => {
+const SimpleChart = ({ data, type = 'line', ariaLabel }: { data: any[], type?: 'line' | 'bar' | 'pie', ariaLabel?: string }) => {
   if (type === 'pie') {
     const total = data.reduce((sum, item) => sum + item.count, 0)
     let currentAngle = 0
-    
+
     return (
-      <div style={{ width: '200px', height: '200px', position: 'relative', margin: '0 auto' }}>
-        <svg width="200" height="200" viewBox="0 0 200 200">
+      <div style={{ width: '40vw', maxWidth: '200px', height: '40vw', maxHeight: '200px', position: 'relative', margin: '0 auto' }}>
+        <svg width="100%" height="100%" viewBox="0 0 200 200" role="img" aria-label={ariaLabel} tabIndex={0}>
           {data.map((item, index) => {
             const percentage = (item.count / total) * 100
             const angle = (percentage / 100) * 360
@@ -190,15 +190,21 @@ const SimpleChart = ({ data, type = 'line' }: { data: any[], type?: 'line' | 'ba
     const width = 300
     const height = 150
     const padding = 20
-    
+
     return (
-      <svg width={width} height={height} style={{ overflow: 'visible' }}>
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        style={{ width: '60vw', height: '30vh', maxWidth: '300px', maxHeight: '150px', overflow: 'visible' }}
+        role="img"
+        aria-label={ariaLabel}
+        tabIndex={0}
+      >
         {/* Ligne de performance */}
         <polyline
           fill="none"
-          stroke="#22c55e"
+          stroke="var(--color-chart-line)"
           strokeWidth="3"
-          points={data.map((d, i) => 
+          points={data.map((d, i) =>
             `${padding + (i * (width - 2 * padding) / (data.length - 1))},${height - padding - (d.ast / maxValue) * (height - 2 * padding)}`
           ).join(' ')}
         />
@@ -209,7 +215,7 @@ const SimpleChart = ({ data, type = 'line' }: { data: any[], type?: 'line' | 'ba
             cx={padding + (i * (width - 2 * padding) / (data.length - 1))}
             cy={height - padding - (d.ast / maxValue) * (height - 2 * padding)}
             r="4"
-            fill="#22c55e"
+            fill="var(--color-chart-line)"
             stroke="white"
             strokeWidth="2"
           />
@@ -880,7 +886,13 @@ export default function ManagerDashboard({ tenant = { id: '1', subdomain: 'demo'
           >
             
             {/* AST Complétés - FONCTIONNEL */}
-            <div className="glass-effect card-hover" style={{ padding: '24px', position: 'relative', overflow: 'hidden' }}>
+            <div
+              className="glass-effect card-hover"
+              style={{ padding: '24px', position: 'relative', overflow: 'hidden' }}
+              tabIndex={0}
+              role="group"
+              aria-label={`AST complétés ${data.astCompleted} sur ${data.totalAST}`}
+            >
               <div style={{ 
                 position: 'absolute', 
                 top: '-50%', 
@@ -955,7 +967,13 @@ export default function ManagerDashboard({ tenant = { id: '1', subdomain: 'demo'
             </div>
 
             {/* AST Mensuels - REMPLACE Conformité */}
-            <div className="glass-effect card-hover" style={{ padding: '24px', position: 'relative', overflow: 'hidden' }}>
+            <div
+              className="glass-effect card-hover"
+              style={{ padding: '24px', position: 'relative', overflow: 'hidden' }}
+              tabIndex={0}
+              role="group"
+              aria-label={`AST mensuels ${data.astThisMonth}`}
+            >
               <div style={{ 
                 position: 'absolute', 
                 top: '-50%', 
@@ -1030,7 +1048,13 @@ export default function ManagerDashboard({ tenant = { id: '1', subdomain: 'demo'
             </div>
 
             {/* Incidents - FONCTIONNEL */}
-            <div className="glass-effect card-hover" style={{ padding: '24px', position: 'relative', overflow: 'hidden' }}>
+            <div
+              className="glass-effect card-hover"
+              style={{ padding: '24px', position: 'relative', overflow: 'hidden' }}
+              tabIndex={0}
+              role="group"
+              aria-label={`Incidents ${data.incidents}`}
+            >
               <div style={{ 
                 position: 'absolute', 
                 top: '-50%', 
@@ -1108,7 +1132,13 @@ export default function ManagerDashboard({ tenant = { id: '1', subdomain: 'demo'
             </div>
 
             {/* Heures Sécuritaires - REMPLACE Économies */}
-            <div className="glass-effect card-hover" style={{ padding: '24px', position: 'relative', overflow: 'hidden' }}>
+            <div
+              className="glass-effect card-hover"
+              style={{ padding: '24px', position: 'relative', overflow: 'hidden' }}
+              tabIndex={0}
+              role="group"
+              aria-label={`Heures sécuritaires ${data.safeHours} sur ${data.hoursWorked}`}
+            >
               <div style={{ 
                 position: 'absolute', 
                 top: '-50%', 
@@ -1255,7 +1285,7 @@ export default function ManagerDashboard({ tenant = { id: '1', subdomain: 'demo'
                   <LineChart style={{ width: '20px', height: '20px' }} />
                   Évolution AST
                 </h3>
-                <SimpleChart data={data.monthlyData} type="line" />
+                <SimpleChart data={data.monthlyData} type="line" ariaLabel="Évolution mensuelle des AST" />
                 <div style={{ marginTop: '16px', display: 'flex', justifyContent: 'space-between', fontSize: '12px', color: '#94a3b8' }}>
                   <span>Jan</span>
                   <span>Mar</span>
@@ -1284,7 +1314,7 @@ export default function ManagerDashboard({ tenant = { id: '1', subdomain: 'demo'
                   <PieChart style={{ width: '20px', height: '20px' }} />
                   Types d'Incidents
                 </h3>
-                <SimpleChart data={data.incidentsByType} type="pie" />
+                <SimpleChart data={data.incidentsByType} type="pie" ariaLabel="Répartition des incidents par type" />
                 <div style={{ marginTop: '16px' }}>
                   {data.incidentsByType.map((item, index) => (
                     <div key={index} style={{ 

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,22 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --color-chart-line: #22c55e;
+  --color-chart-electrique: #ef4444;
+  --color-chart-chute: #f97316;
+  --color-chart-equipement: #eab308;
+}
+
+@media (prefers-contrast: more) {
+  :root {
+    --color-chart-line: #000;
+    --color-chart-electrique: #000;
+    --color-chart-chute: #000;
+    --color-chart-equipement: #000;
+  }
+}
+
 @keyframes slideDown {
   from {
     opacity: 0;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -29,6 +29,10 @@ const config: Config = {
         'ast-red': '#e74c3c',
         'ast-yellow': '#f39c12',
         'ast-purple': '#9b59b6',
+        'chart-line': 'var(--color-chart-line)',
+        'chart-electrique': 'var(--color-chart-electrique)',
+        'chart-chute': 'var(--color-chart-chute)',
+        'chart-equipement': 'var(--color-chart-equipement)',
       },
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',


### PR DESCRIPTION
## Summary
- use CSS variables and Tailwind theme entries for chart colors with high-contrast fallbacks
- refactor SimpleChart to be responsive and expose ARIA labels
- add focusable KPI cards with descriptive labels

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (requires interactive setup)

------
https://chatgpt.com/codex/tasks/task_e_689a98f9a23883238e3555172c699d2a