### PR TITLE
feat: add language context and switcher

### DIFF
--- a/app/LanguageContext.tsx
+++ b/app/LanguageContext.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+import { setLanguage as setGlobalLanguage, getCurrentLanguage } from '@/utils/translations'
+
+export type Language = 'fr' | 'en'
+
+interface LanguageContextValue {
+  language: Language
+  setLanguage: (lang: Language) => void
+}
+
+const LanguageContext = createContext<LanguageContextValue>({
+  language: 'fr',
+  setLanguage: () => {},
+})
+
+const STORAGE_KEY = 'language'
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [language, setLanguageState] = useState<Language>('fr')
+
+  useEffect(() => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null
+    const initial = (stored === 'fr' || stored === 'en') ? (stored as Language) : getCurrentLanguage()
+    setLanguageState(initial)
+    setGlobalLanguage(initial)
+  }, [])
+
+  const setLanguage = (lang: Language) => {
+    setLanguageState(lang)
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(STORAGE_KEY, lang)
+    }
+    setGlobalLanguage(lang)
+  }
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  )
+}
+
+export const useLanguage = () => useContext(LanguageContext)
+

--- a/app/RootLayoutClient.tsx
+++ b/app/RootLayoutClient.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { ReactNode } from 'react'
+import { LanguageProvider, useLanguage } from './LanguageContext'
+
+interface Props {
+  children: ReactNode
+  className: string
+}
+
+export default function RootLayoutClient({ children, className }: Props) {
+  return (
+    <LanguageProvider>
+      <InnerLayout className={className}>{children}</InnerLayout>
+    </LanguageProvider>
+  )
+}
+
+function InnerLayout({ children, className }: { children: ReactNode; className: string }) {
+  const { language } = useLanguage()
+
+  return (
+    <html lang={language}>
+      <head>
+        <link rel="icon" href="/favicon.ico" />
+        <meta name="theme-color" content="#3498db" />
+        <meta name="mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+        <meta name="apple-mobile-web-app-title" content="AST MDL" />
+      </head>
+      <body className={className}>{children}</body>
+    </html>
+  )
+}
+

--- a/app/[tenant]/dashboard/LanguageSwitcher.tsx
+++ b/app/[tenant]/dashboard/LanguageSwitcher.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { useLanguage } from '@/LanguageContext'
+
+export default function LanguageSwitcher() {
+  const { language, setLanguage } = useLanguage()
+
+  const toggle = () => setLanguage(language === 'fr' ? 'en' : 'fr')
+
+  return (
+    <button
+      onClick={toggle}
+      className="px-2 py-1 text-xs border rounded"
+    >
+      {language === 'fr' ? 'EN' : 'FR'}
+    </button>
+  )
+}
+

--- a/app/[tenant]/dashboard/ManagerDashboard.tsx
+++ b/app/[tenant]/dashboard/ManagerDashboard.tsx
@@ -2,6 +2,8 @@
 
 import Link from 'next/link'
 import { useState, useEffect } from 'react'
+import { t } from '@/utils/translations'
+import LanguageSwitcher from './LanguageSwitcher'
 import { 
   BarChart3, 
   TrendingUp, 
@@ -502,6 +504,10 @@ export default function ManagerDashboard({ tenant = { id: '1', subdomain: 'demo'
           }
         `
       }} />
+
+      <div className="p-4 flex justify-end">
+        <LanguageSwitcher />
+      </div>
 
       <div className="dashboard-container">
         {/* Fond interactif qui suit la souris */}
@@ -1050,7 +1056,7 @@ export default function ManagerDashboard({ tenant = { id: '1', subdomain: 'demo'
                     textTransform: 'uppercase', 
                     letterSpacing: '0.1em' 
                   }}>
-                    Incidents
+                    {t('dashboard.incidents')}
                   </p>
                   <p style={{ 
                     color: 'white', 
@@ -1282,7 +1288,7 @@ export default function ManagerDashboard({ tenant = { id: '1', subdomain: 'demo'
                   gap: '8px'
                 }}>
                   <PieChart style={{ width: '20px', height: '20px' }} />
-                  Types d'Incidents
+                  {t('dashboard.incidentTypes')}
                 </h3>
                 <SimpleChart data={data.incidentsByType} type="pie" />
                 <div style={{ marginTop: '16px' }}>
@@ -1325,7 +1331,7 @@ export default function ManagerDashboard({ tenant = { id: '1', subdomain: 'demo'
                   gap: '8px'
                 }}>
                   <Camera style={{ width: '20px', height: '20px' }} />
-                  Photos Documentation
+                  {t('dashboard.photoDocumentation')}
                 </h3>
                 <div style={{ textAlign: 'center' }}>
                   <div style={{ 
@@ -1338,10 +1344,10 @@ export default function ManagerDashboard({ tenant = { id: '1', subdomain: 'demo'
                     {data.photosCount}
                   </div>
                   <div style={{ color: '#22c55e', fontSize: '14px', fontWeight: '600' }}>
-                    Photos totales
+                    {t('dashboard.totalPhotos')}
                   </div>
                   <div style={{ color: '#94a3b8', fontSize: '12px', marginTop: '8px' }}>
-                    +{data.photosThisWeek} cette semaine
+                    +{data.photosThisWeek} {t('dashboard.thisWeek')}
                   </div>
                   
                   <div style={{

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import './globals.css'
+import RootLayoutClient from './RootLayoutClient'
 const inter = Inter({ subsets: ['latin'] })
 
 // ✅ VIEWPORT SÉPARÉ (obligatoire Next.js 14+)
@@ -23,17 +24,5 @@ export default function RootLayout({
 }: {
   children: React.ReactNode
 }) {
-  return (
-    <html lang="fr">
-      <head>
-        <link rel="icon" href="/favicon.ico" />
-        <meta name="theme-color" content="#3498db" />
-        <meta name="mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-        <meta name="apple-mobile-web-app-title" content="AST MDL" />
-      </head>
-      <body className={inter.className}>{children}</body>
-    </html>
-  )
+  return <RootLayoutClient className={inter.className}>{children}</RootLayoutClient>
 }

--- a/app/utils/translations.ts
+++ b/app/utils/translations.ts
@@ -96,7 +96,16 @@ export const TRANSLATIONS: LanguageResources = {
       urgent: 'Urgente',
       critical: 'Critique'
     },
-    
+
+    // Tableau de bord
+    dashboard: {
+      incidents: 'Incidents',
+      incidentTypes: "Types d'Incidents",
+      photoDocumentation: 'Photos Documentation',
+      totalPhotos: 'Photos totales',
+      thisWeek: 'cette semaine'
+    },
+
     // AST spécifique
     ast: {
       title: 'Analyse Sécuritaire de Tâches',
@@ -343,7 +352,16 @@ export const TRANSLATIONS: LanguageResources = {
       urgent: 'Urgent',
       critical: 'Critical'
     },
-    
+
+    // Dashboard
+    dashboard: {
+      incidents: 'Incidents',
+      incidentTypes: 'Incident Types',
+      photoDocumentation: 'Photo Documentation',
+      totalPhotos: 'Total Photos',
+      thisWeek: 'this week'
+    },
+
     // AST specific
     ast: {
       title: 'Job Safety Analysis',


### PR DESCRIPTION
## Summary
- add `LanguageContext` to persist language selection
- wrap root layout with provider and propagate language to `<html lang>`
- add dashboard language switcher and translate key dashboard strings

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompted for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_689a98fc0a488323bd853f485f4e3d5d