### PR TITLE
Use SafetyManager entry registry data and subscribe to store updates

### DIFF
--- a/components/steps/Step4Permits/ConfinedSpace/EntryRegistry.tsx
+++ b/components/steps/Step4Permits/ConfinedSpace/EntryRegistry.tsx
@@ -192,17 +192,26 @@ const EntryRegistry: React.FC<ConfinedSpaceComponentProps> = ({
   onSectionComplete,
   onValidationChange
 }) => {
-  // ✅ CORRECTION CRASH : Accès sécurisé aux données depuis permitData
-  const entryRegistryData = permitData?.entryRegistry || {
-    personnel: [],
-    entryLogs: [],
-    currentOccupancy: 0,
-    maxOccupancy: 3,
-    attendantPresent: false,
-    communicationSystemActive: false,
-    emergencyContactsNotified: false,
-    lastUpdated: new Date().toISOString()
-  };
+  // ✅ Derive registry data directly from SafetyManager store
+  const [entryRegistryData, setEntryRegistryData] = useState<EntryRegistryData>(() => (
+    safetyManager?.currentPermit?.entryRegistry || {
+      personnel: [],
+      entryLogs: [],
+      currentOccupancy: 0,
+      maxOccupancy: 3,
+      attendantPresent: false,
+      communicationSystemActive: false,
+      emergencyContactsNotified: false,
+      lastUpdated: new Date().toISOString()
+    }
+  ));
+
+  // Subscribe to store updates so changes reflect immediately
+  useEffect(() => {
+    if (safetyManager?.currentPermit?.entryRegistry) {
+      setEntryRegistryData(safetyManager.currentPermit.entryRegistry);
+    }
+  }, [safetyManager?.currentPermit?.entryRegistry]);
 
   const personnel = entryRegistryData?.personnel || [];
   const entryLogs = entryRegistryData?.entryLogs || [];


### PR DESCRIPTION
## Summary
- Derive entry registry state from `safetyManager.currentPermit.entryRegistry` instead of `permitData`
- Subscribe to store updates so registry edits render immediately

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689aa77a7f0883238fe0db4d12c65120