### PR TITLE
feat: validate AST request payload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-dom": "^18",
         "tailwind-merge": "^2.2.0",
         "tailwindcss": "^3.3.0",
+        "zod": "^3.25.76",
         "zustand": "^4.4.7"
       },
       "devDependencies": {
@@ -8208,6 +8209,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-dom": "^18",
     "tailwind-merge": "^2.2.0",
     "tailwindcss": "^3.3.0",
+    "zod": "^3.25.76",
     "zustand": "^4.4.7"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add zod dependency
- validate AST POST request body and return 400 on invalid input

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689b44d35e448323a3d8125dae9cf32c