### PR TITLE
chore: specify success status for NextResponse

### DIFF
--- a/app/api/ast/route.ts
+++ b/app/api/ast/route.ts
@@ -45,11 +45,11 @@ export async function POST(request: NextRequest) {
       }
     })
     
-    return NextResponse.json({ 
-      success: true, 
+    return NextResponse.json({
+      success: true,
       astForm,
       message: 'AST sauvegardé avec succès!'
-    })
+    }, { status: 200 })
     
   } catch (error: any) {
     console.error('Error saving AST:', error)
@@ -82,7 +82,7 @@ export async function GET(request: NextRequest) {
       orderBy: { createdAt: 'desc' }
     })
     
-    return NextResponse.json({ astForms })
+    return NextResponse.json({ astForms }, { status: 200 })
     
   } catch (error: any) {
     return NextResponse.json({ 

--- a/app/api/db/init/route.ts
+++ b/app/api/db/init/route.ts
@@ -48,8 +48,8 @@ export async function GET() {
     
     await prisma.$disconnect()
     
-    return NextResponse.json({ 
-      success: true, 
+    return NextResponse.json({
+      success: true,
       message: '🎉 Base de données connectée et tenants créés!',
       tenants: [demoTenant, futureClientTenant, csecurTenant],
       totalTenants: existingTenants.length,
@@ -58,7 +58,7 @@ export async function GET() {
         futureclient: futureClientTenant.companyName,
         admin: csecurTenant.companyName
       }
-    })
+    }, { status: 200 })
     
   } catch (error: unknown) {
     console.error('❌ Database error:', error)


### PR DESCRIPTION
## Summary
- add explicit 200 status to AST API success responses
- ensure DB init route's success response returns HTTP 200

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689b44dd13948323bece9fd8a949c811