### PR TITLE
feat: extend NextAuth types with user id

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,6 @@
       "@/types/*": ["./app/types/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types/**/*.d.ts", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,0 +1,13 @@
+import { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id: string;
+    } & DefaultSession["user"];
+  }
+
+  interface User {
+    id: string;
+  }
+}


### PR DESCRIPTION
## Summary
- add type augmentation for `next-auth` to expose `id` on `User` and `Session.user`
- include new `types` directory in `tsconfig.json`

## Testing
- `npm test`
- `npm run build` *(fails: PrismaClientInitializationError: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_689b4992600c8323b9d3b84c3bebc8c0