### PR TITLE
chore(types): ensure next-auth user id typings

### DIFF
--- a/hooks/useTeamSharing.ts
+++ b/hooks/useTeamSharing.ts
@@ -80,7 +80,7 @@ export const useTeamSharing = (astId: string) => {
   const [isSharing, setIsSharing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { data: session } = useSession();
-  const currentUserId = session?.user?.id || '';
+  const currentUserId = (session?.user as { id: string } | undefined)?.id || '';
   const currentUserName = session?.user?.name || 'Équipe Sécurité';
 
   // Templates de notification prédéfinis

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
       "@/components/*": ["./components/*"],
       "@/lib/*": ["./lib/*"],
       "@/types/*": ["./app/types/*"]
-    }
+    },
+    "typeRoots": ["./types", "./node_modules/@types"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types/**/*.d.ts", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- include local types directory via `typeRoots` so NextAuth session user id augmentation is picked up
- cast `session.user` to a type with `id` when deriving `currentUserId`

## Testing
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689b4dd1a7248323a34cdbd067a2c295