### PR TITLE
feat: add typed AST form data

### DIFF
--- a/app/[tenant]/ast/nouveau/page.tsx
+++ b/app/[tenant]/ast/nouveau/page.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useEffect } from 'react';
 import ASTForm from '@/components/ASTForm';
+import { ASTFormData } from '../../../types/astForm';
 
 interface PageProps {
   params: {
@@ -11,7 +12,7 @@ interface PageProps {
 }
 
 export default function NouvellePage({ params }: PageProps) {
-  const [astData, setAstData] = useState({
+  const [astData, setAstData] = useState<ASTFormData>({
     id: '',
     astNumber: '',
     projectInfo: {
@@ -77,7 +78,7 @@ export default function NouvellePage({ params }: PageProps) {
   }, [params.tenant]);
 
   // ✅ HANDLER POUR SYNC DONNÉES
-  const handleDataChange = (section: string, data: any) => {
+  const handleDataChange = <K extends keyof ASTFormData>(section: K, data: ASTFormData[K]) => {
     console.log('📝 Page - Data changed:', { section, data });
     setAstData(prev => ({
       ...prev,

--- a/app/[tenant]/ast/page.tsx
+++ b/app/[tenant]/ast/page.tsx
@@ -3,56 +3,45 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import ASTForm from '@/components/ASTForm';
-import { AST } from '../../types/ast';
+import { ASTFormData } from '../../types/astForm';
 
 export default function ASTPage() {
   const params = useParams();
   const router = useRouter();
   const tenant = params?.tenant as string;
 
-  const [formData, setFormData] = useState<Partial<AST>>({
+  const [formData, setFormData] = useState<ASTFormData>({
     id: '',
-    tenant: tenant || '',
+    astNumber: '',
     projectInfo: {
-      workType: '',
-      workTypeDetails: {
-        category: '',
-        subcategory: '',
-        complexity: 'simple',
-        frequency: 'routine',
-        criticality: 'low'
-      },
-      location: {
-        site: '',
-        building: '',
-        floor: '',
-        room: '',
-        specificArea: ''
-      },
-      estimatedDuration: '',
-      actualDuration: '',
-      equipmentRequired: [],
-      environmentalConditions: {
-        temperature: { min: 20, max: 25, units: 'celsius' },
-        humidity: 50,
-        lighting: { 
-          type: 'artificial', 
-          adequacy: 'good', 
-          requiresSupplemental: false 
-        },
-        noise: { level: 0, requiresProtection: false },
-        airQuality: { 
-          quality: 'good', 
-          requiresVentilation: false, 
-          requiresRespiratory: false 
-        },
-        weather: { 
-          condition: 'clear', 
-          impactsWork: false 
-        }
-      }
+      client: '',
+      workLocation: '',
+      industry: '',
+      projectNumber: '',
+      date: '',
+      time: '',
+      workDescription: '',
+      workerCount: 1,
+      lockoutPoints: []
     },
-    status: 'draft'
+    equipment: {
+      selected: [],
+      custom: []
+    },
+    hazards: {
+      selected: [],
+      controls: []
+    },
+    permits: {
+      permits: []
+    },
+    validation: {
+      reviewers: []
+    },
+    finalization: {
+      consent: false,
+      signatures: []
+    }
   });
 
   const [loading, setLoading] = useState(true);
@@ -94,14 +83,14 @@ export default function ASTPage() {
     loadData();
   }, [tenant]);
 
-  const handleDataChange = useCallback(async (section: string, data: any) => {
+  const handleDataChange = useCallback(async <K extends keyof ASTFormData>(section: K, data: ASTFormData[K]) => {
     setSaving(true);
-    
+
     setFormData(prev => {
-      const newData = {
+      const newData: ASTFormData = {
         ...prev,
         [section]: data,
-        updatedAt: new Date()
+        updatedAt: new Date().toISOString()
       };
       
       setTimeout(async () => {

--- a/app/[tenant]/page.tsx
+++ b/app/[tenant]/page.tsx
@@ -3,56 +3,45 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import ASTForm from '@/components/ASTForm';
-import { AST } from '../types/ast';
+import { ASTFormData } from '../types/astForm';
 
 export default function ASTPage() {
   const params = useParams();
   const router = useRouter();
   const tenant = params?.tenant as string;
 
-  const [formData, setFormData] = useState<Partial<AST>>({
+  const [formData, setFormData] = useState<ASTFormData>({
     id: '',
-    tenant: tenant || '',
+    astNumber: '',
     projectInfo: {
-      workType: '',
-      workTypeDetails: {
-        category: '',
-        subcategory: '',
-        complexity: 'simple',
-        frequency: 'routine',
-        criticality: 'low'
-      },
-      location: {
-        site: '',
-        building: '',
-        floor: '',
-        room: '',
-        specificArea: ''
-      },
-      estimatedDuration: '',
-      actualDuration: '',
-      equipmentRequired: [],
-      environmentalConditions: {
-        temperature: { min: 20, max: 25, units: 'celsius' },
-        humidity: 50,
-        lighting: { 
-          type: 'artificial', 
-          adequacy: 'good', 
-          requiresSupplemental: false 
-        },
-        noise: { level: 0, requiresProtection: false },
-        airQuality: { 
-          quality: 'good', 
-          requiresVentilation: false, 
-          requiresRespiratory: false 
-        },
-        weather: { 
-          condition: 'clear', 
-          impactsWork: false 
-        }
-      }
+      client: '',
+      workLocation: '',
+      industry: '',
+      projectNumber: '',
+      date: '',
+      time: '',
+      workDescription: '',
+      workerCount: 1,
+      lockoutPoints: []
     },
-    status: 'draft'
+    equipment: {
+      selected: [],
+      custom: []
+    },
+    hazards: {
+      selected: [],
+      controls: []
+    },
+    permits: {
+      permits: []
+    },
+    validation: {
+      reviewers: []
+    },
+    finalization: {
+      consent: false,
+      signatures: []
+    }
   });
 
   const [loading, setLoading] = useState(true);
@@ -94,14 +83,14 @@ export default function ASTPage() {
     loadData();
   }, [tenant]);
 
-  const handleDataChange = useCallback(async (section: string, data: any) => {
+  const handleDataChange = useCallback(async <K extends keyof ASTFormData>(section: K, data: ASTFormData[K]) => {
     setSaving(true);
-    
+
     setFormData(prev => {
-      const newData = {
+      const newData: ASTFormData = {
         ...prev,
         [section]: data,
-        updatedAt: new Date()
+        updatedAt: new Date().toISOString()
       };
       
       setTimeout(async () => {

--- a/app/types/astForm.ts
+++ b/app/types/astForm.ts
@@ -1,0 +1,51 @@
+export interface ProjectInfo {
+  client: string;
+  workLocation: string;
+  industry: string;
+  projectNumber: string;
+  date: string;
+  time: string;
+  workDescription: string;
+  workerCount: number;
+  lockoutPoints: string[];
+}
+
+export interface EquipmentData {
+  selected: string[];
+  custom: string[];
+}
+
+export interface HazardsData {
+  selected: string[];
+  controls: string[];
+}
+
+export interface PermitsData {
+  permits: string[];
+}
+
+export interface ValidationData {
+  reviewers: string[];
+}
+
+export interface FinalizationData {
+  consent: boolean;
+  signatures: string[];
+}
+
+export interface ASTFormData {
+  id: string;
+  astNumber: string;
+  projectInfo: ProjectInfo;
+  equipment: EquipmentData;
+  hazards: HazardsData;
+  permits: PermitsData;
+  validation: ValidationData;
+  finalization: FinalizationData;
+  tenant?: string;
+  status?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  createdBy?: string;
+  language?: 'fr' | 'en';
+}

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -514,3 +514,5 @@ export type {
 export type {
   ApiResponse as APIResponse
 } from './api';
+
+export type { ASTFormData } from './astForm';

--- a/components/ASTForm.tsx
+++ b/components/ASTForm.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { 
-  FileText, ArrowLeft, ArrowRight, Save, Eye, Download, CheckCircle, 
-  AlertTriangle, Clock, Shield, Users, MapPin, Calendar, Building, 
+import {
+  FileText, ArrowLeft, ArrowRight, Save, Eye, Download, CheckCircle,
+  AlertTriangle, Clock, Shield, Users, MapPin, Calendar, Building,
   Phone, User, Briefcase, Copy, Check, Camera, HardHat, Zap, Settings,
   Plus, Trash2, Edit, Star, Wifi, WifiOff, Upload, Bell, Wrench, Wind,
   Droplets, Flame, Activity, Search, Filter, Hand, MessageSquare
 } from 'lucide-react';
+import { ASTFormData } from '@/app/types/astForm';
 
 // =================== ✅ IMPORTS DES COMPOSANTS STEPS 1-6 (CONSERVÉS INTÉGRALEMENT) ===================
 import Step1ProjectInfo from '@/components/steps/Step1ProjectInfo';
@@ -18,13 +19,13 @@ import Step5Validation from '@/components/steps/Step5Validation';
 import Step6Finalization from '@/components/steps/Step6Finalization';
 
 // =================== INTERFACES PRINCIPALES (CONSERVÉES) ===================
-interface ASTFormProps {
+interface ASTFormProps<T extends ASTFormData = ASTFormData> {
   tenant: string;
   language: 'fr' | 'en';
   userId?: string;
   userRole?: 'worker' | 'supervisor' | 'manager' | 'admin';
-  formData: any;
-  onDataChange: (section: string, data: any) => void;
+  formData: T;
+  onDataChange: <K extends keyof T>(section: K, data: T[K]) => void;
 }
 
 // =================== TRADUCTIONS COMPLÈTES (CONSERVÉES INTÉGRALEMENT) ===================
@@ -225,14 +226,14 @@ const useIsMobile = () => {
 };
 
 // =================== COMPOSANT PRINCIPAL ASTFORM ===================
-export default function ASTForm({ 
-  tenant, 
-  language: initialLanguage = 'fr', 
-  userId, 
+export default function ASTForm<T extends ASTFormData = ASTFormData>({
+  tenant,
+  language: initialLanguage = 'fr',
+  userId,
   userRole = 'worker',
   formData,
   onDataChange
-}: ASTFormProps) {
+}: ASTFormProps<T>) {
   
   // =================== GESTION DE LA LANGUE OPTIMISÉE (CONSERVÉE) ===================
   const [currentLanguage, setCurrentLanguage] = useState<'fr' | 'en'>(() => {
@@ -259,7 +260,7 @@ export default function ASTForm({
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
   // =================== DONNÉES AST STABLES (CONSERVÉES) ===================
-  const [astData, setAstData] = useState(() => ({
+  const [astData, setAstData] = useState<T>(() => ({
     ...formData,
     id: formData.id || `ast_${Date.now()}`,
     astNumber: formData.astNumber || `AST-${tenant.toUpperCase()}-${new Date().getFullYear()}-${String(Date.now()).slice(-6)}`,
@@ -269,18 +270,18 @@ export default function ASTForm({
     updatedAt: new Date().toISOString(),
     createdBy: userId || 'user_anonymous',
     language: currentLanguage
-  }));
+  }) as T);
 
   // =================== 🔥 FIX ANTI-BOUCLES ULTRA-STABLE ===================
-  const stableFormDataRef = useRef(astData);
+  const stableFormDataRef = useRef<T>(astData);
   const renderCountRef = useRef(0);
   const lastUpdateRef = useRef<string>('');
   
   // ✅ HANDLER ULTRA-STABLE - INITIALISÉ UNE SEULE FOIS AVEC DEBOUNCE
-  const stableHandlerRef = useRef<(section: string, data: any) => void>();
+  const stableHandlerRef = useRef<(section: keyof T, data: T[keyof T]) => void>();
   
   if (!stableHandlerRef.current) {
-    stableHandlerRef.current = (section: string, data: any) => {
+    stableHandlerRef.current = (section, data) => {
       const updateKey = `${section}-${JSON.stringify(data).slice(0, 50)}`;
       
       // ✅ ÉVITER LES DOUBLONS
@@ -293,12 +294,12 @@ export default function ASTForm({
       console.log('🔥 HANDLER ULTRA-STABLE (ANTI-BOUCLES):', { section, renderCount: renderCountRef.current });
       
       // ✅ MISE À JOUR SYNCHRONE DE L'ÉTAT LOCAL
-      setAstData((prev: any) => {
+      setAstData((prev: T) => {
         const newData = {
           ...prev,
           [section]: data,
           updatedAt: new Date().toISOString()
-        };
+        } as T;
         
         // ✅ MISE À JOUR DE LA REF POUR ÉVITER LES RE-RENDERS
         stableFormDataRef.current = newData;


### PR DESCRIPTION
## Summary
- define explicit `ASTFormData` interface for AST forms
- use generics in `ASTForm` for strongly typed data and change handler
- update tenant pages to pass `ASTFormData`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b576077ec832384cec8926dfe5ae1