### PR TITLE
Use crypto.randomUUID for session IDs

### DIFF
--- a/hooks/useTeamSharing.ts
+++ b/hooks/useTeamSharing.ts
@@ -328,7 +328,7 @@ export const useTeamSharing = (astId: string) => {
 
   // Fonction pour générer un ID de session
   const generateSessionId = (): string => {
-    return `ast-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    return `ast-${Date.now()}-${crypto.randomUUID()}`;
   };
 
   // Fonction pour générer un lien de partage


### PR DESCRIPTION
## Summary
- use `crypto.randomUUID` for generating share session IDs

## Testing
- `npm run build`
- `npm test`
- `node - <<'NODE'
const ids=new Set();
const generateSessionId=()=>`ast-${Date.now()}-${crypto.randomUUID()}`;
for(let i=0;i<5;i++){
  const id=generateSessionId();
  console.log(id);
  ids.add(id);
}
console.log('Unique IDs generated:', ids.size);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689b5809839083239282a5b22057b77e