### PR TITLE
Clarify user ID retrieval in team sharing hook

### DIFF
--- a/hooks/useTeamSharing.ts
+++ b/hooks/useTeamSharing.ts
@@ -80,6 +80,7 @@ export const useTeamSharing = (astId: string) => {
   const [isSharing, setIsSharing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { data: session } = useSession();
+  // Extract current user ID from the session, defaulting to an empty string when not available
   const currentUserId = (session?.user as { id: string } | undefined)?.id || '';
   const currentUserName = session?.user?.name || 'Équipe Sécurité';
 


### PR DESCRIPTION
## Summary
- explain extraction of current user ID from session in `useTeamSharing`

## Testing
- `npm test`
- `npm run build` *(fails: PrismaClientInitializationError: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_689b580780808323b40b9cdfbd200128