### PR TITLE
Parallelize team invitation dispatch

### DIFF
--- a/hooks/useTeamSharing.ts
+++ b/hooks/useTeamSharing.ts
@@ -209,22 +209,24 @@ export const useTeamSharing = (astId: string) => {
 
   // Fonction pour envoyer les invitations
   const sendInvitations = async (session: ShareSession) => {
-    for (const member of session.members) {
-      try {
-        if (member.notificationPreferences.email) {
-          await sendEmailInvitation(member, session);
-        }
-        if (member.notificationPreferences.sms) {
-          if (member.phone) {
-            await sendSMSInvitation(member, session);
-          } else {
-            console.warn(`Numéro de téléphone manquant pour ${member.name}, invitation SMS ignorée.`);
+    await Promise.all(
+      session.members.map(async member => {
+        try {
+          if (member.notificationPreferences.email) {
+            await sendEmailInvitation(member, session);
           }
+          if (member.notificationPreferences.sms) {
+            if (member.phone) {
+              await sendSMSInvitation(member, session);
+            } else {
+              console.warn(`Numéro de téléphone manquant pour ${member.name}, invitation SMS ignorée.`);
+            }
+          }
+        } catch (err) {
+          console.error(`Erreur envoi invitation à ${member.name}:`, err);
         }
-      } catch (err) {
-        console.error(`Erreur envoi invitation à ${member.name}:`, err);
-      }
-    }
+      })
+    );
   };
 
   // Fonction pour envoyer invitation email


### PR DESCRIPTION
## Summary
- parallelize invitation sending with `Promise.all` to avoid blocking when notifying multiple team members

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run build` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_689b58084c2c832388b22daae0e11ba8