### PR TITLE
feat: connect weather hook to OpenWeatherMap API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,4 @@ NEXTAUTH_URL="https://your-deployment-url"
 
 NEXT_PUBLIC_APP_NAME="AST MDL"
 NEXT_PUBLIC_DEFAULT_TENANT="demo"
+WEATHER_API_KEY="your-openweather-api-key"

--- a/hooks/useWeatherData.ts
+++ b/hooks/useWeatherData.ts
@@ -1,5 +1,6 @@
 // hooks/useWeatherData.ts
 import { useState, useEffect } from 'react';
+import { getWeatherData } from '@/lib/weatherApi';
 
 export interface WeatherData {
   temperature: number;
@@ -45,50 +46,20 @@ export const useWeatherData = (coordinates: Coordinates) => {
     setError(null);
     
     try {
-      // En développement, utiliser des données simulées
-      const mockWeather: WeatherData = generateMockWeather();
-      
-      // En production, vous pourriez utiliser une vraie API météo
-      // const response = await fetch(`/api/weather?lat=${coordinates.lat}&lng=${coordinates.lng}`);
-      // const weatherData = await response.json();
-      
-      setWeather(mockWeather);
-      
+      const weatherData = await getWeatherData(coordinates.lat, coordinates.lng);
+      setWeather(weatherData);
+
       // Générer des alertes basées sur les conditions
-      const generatedAlerts = generateWeatherAlerts(mockWeather);
+      const generatedAlerts = generateWeatherAlerts(weatherData);
       setAlerts(generatedAlerts);
-      
+
     } catch (err) {
-      setError('Erreur lors de la récupération des données météo');
+      const message = err instanceof Error ? err.message : 'Erreur lors de la récupération des données météo';
+      setError(message);
       console.error('Erreur météo:', err);
     } finally {
       setLoading(false);
     }
-  };
-
-  const generateMockWeather = (): WeatherData => {
-    const temp = Math.round(Math.random() * 40 - 15); // -15°C à 25°C
-    const humidity = Math.round(Math.random() * 100);
-    const windSpeed = Math.round(Math.random() * 60);
-    const conditions = ['ensoleillé', 'nuageux', 'pluvieux', 'neigeux', 'orageux'][Math.floor(Math.random() * 5)];
-    
-    return {
-      temperature: temp,
-      humidity,
-      windSpeed,
-      windDirection: ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'][Math.floor(Math.random() * 8)],
-      precipitation: Math.round(Math.random() * 20),
-      visibility: Math.round(Math.random() * 10 + 5),
-      uvIndex: Math.round(Math.random() * 11),
-      conditions,
-      warnings: [],
-      impact: temp < -20 || temp > 35 || windSpeed > 50 ? 'high' : 
-              temp < -10 || temp > 30 || windSpeed > 30 ? 'medium' : 'low',
-      pressure: Math.round(Math.random() * 50 + 980), // 980-1030 hPa
-      feelsLike: temp + (windSpeed > 20 ? -5 : 0),
-      dewPoint: temp - Math.round(Math.random() * 15),
-      cloudCover: Math.round(Math.random() * 100)
-    };
   };
 
   const generateWeatherAlerts = (weather: WeatherData): WeatherAlert[] => {

--- a/lib/weatherApi.ts
+++ b/lib/weatherApi.ts
@@ -1,0 +1,66 @@
+import type { WeatherData } from '../hooks/useWeatherData';
+
+const API_BASE = 'https://api.openweathermap.org/data/3.0/onecall';
+const DEFAULT_TIMEOUT = 5000;
+
+const degToCompass = (deg: number): string => {
+  const directions = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
+  return directions[Math.round(deg / 45) % 8];
+};
+
+export async function getWeatherData(lat: number, lng: number): Promise<WeatherData> {
+  const apiKey = process.env.WEATHER_API_KEY;
+  if (!apiKey) {
+    throw new Error('WEATHER_API_KEY is not defined');
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT);
+
+  try {
+    const url = `${API_BASE}?lat=${lat}&lon=${lng}&units=metric&appid=${apiKey}`;
+    const response = await fetch(url, { signal: controller.signal });
+
+    if (!response.ok) {
+      throw new Error(`Weather API error: ${response.status}`);
+    }
+
+    const data = await response.json();
+    clearTimeout(timeout);
+
+    const temp = data.current.temp;
+    const windSpeed = data.current.wind_speed;
+
+    const weather: WeatherData = {
+      temperature: temp,
+      humidity: data.current.humidity,
+      windSpeed,
+      windDirection: degToCompass(data.current.wind_deg),
+      precipitation: data.current.rain?.['1h'] ?? 0,
+      visibility: data.current.visibility ?? 0,
+      uvIndex: data.current.uvi ?? 0,
+      conditions: data.current.weather?.[0]?.description ?? 'Unknown',
+      warnings: [],
+      impact:
+        temp < -20 || temp > 35 || windSpeed > 50
+          ? 'high'
+          : temp < -10 || temp > 30 || windSpeed > 30
+          ? 'medium'
+          : 'low',
+      pressure: data.current.pressure,
+      feelsLike: data.current.feels_like,
+      dewPoint: data.current.dew_point ?? temp,
+      cloudCover: data.current.clouds ?? 0,
+    };
+
+    return weather;
+  } catch (error: any) {
+    clearTimeout(timeout);
+    if (error.name === 'AbortError') {
+      throw new Error('Weather API request timed out');
+    }
+    throw error;
+  }
+}
+
+export default { getWeatherData };


### PR DESCRIPTION
## Summary
- fetch real weather data from OpenWeatherMap using new service module
- use service in weather hook with error handling and timeout management
- document WEATHER_API_KEY in environment example

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b5c0922bc8323be445c8462cc119a