### PR TITLE
refactor: type AST context data

### DIFF
--- a/components/ASTContext.tsx
+++ b/components/ASTContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { createContext, useContext, useReducer, useCallback, useRef, useState, useEffect } from 'react';
+import { ASTFormData } from '@/types/astForm';
 
 // =================== INTERFACES MULTI-TENANT ===================
 export interface TenantConfig {
@@ -27,7 +28,7 @@ export interface TenantConfig {
 }
 
 export interface ASTState {
-  formData: any;
+  formData: ASTFormData;
   currentStep: number;
   errors: Record<string, string>;
   isDirty: boolean;
@@ -36,8 +37,8 @@ export interface ASTState {
 }
 
 // =================== ACTIONS TYPES ===================
-type ASTAction = 
-  | { type: 'UPDATE_STEP_DATA'; section: string; data: any }
+type ASTAction =
+  | { type: 'UPDATE_STEP_DATA'; section: keyof ASTFormData; data: ASTFormData[keyof ASTFormData] }
   | { type: 'SET_CURRENT_STEP'; step: number }
   | { type: 'SET_LANGUAGE'; language: 'fr' | 'en' }
   | { type: 'MARK_SAVED' }
@@ -105,7 +106,7 @@ interface ASTContextValue {
   dispatch: React.Dispatch<ASTAction>;
   
   // Actions principales
-  updateStepData: (section: string, data: any) => void;
+  updateStepData: <K extends keyof ASTFormData>(section: K, data: ASTFormData[K]) => void;
   setCurrentStep: (step: number) => void;
   setLanguage: (language: 'fr' | 'en') => void;
   
@@ -127,16 +128,16 @@ interface ASTContextValue {
 const ASTContext = createContext<ASTContextValue | null>(null);
 
 // =================== PROVIDER ULTRA-STABLE ===================
-export function ASTProvider({ 
-  children, 
-  tenant, 
+export function ASTProvider({
+  children,
+  tenant,
   initialData = {},
   language = 'fr',
   userId
-}: { 
+}: {
   children: React.ReactNode;
   tenant: TenantConfig;
-  initialData?: any;
+  initialData?: Partial<ASTFormData>;
   language?: 'fr' | 'en';
   userId?: string;
 }) {
@@ -144,12 +145,13 @@ export function ASTProvider({
   // ✅ ÉTAT INITIAL STABLE
   const [state, dispatch] = useReducer(astReducer, {
     formData: {
-      ...initialData,
-      tenantId: tenant.id,
+      ...(initialData as ASTFormData),
+      tenant: tenant.id,
       astNumber: `AST-${tenant.id.toUpperCase()}-${Date.now()}`,
-      userId: userId || 'anonymous',
-      createdAt: new Date().toISOString()
-    },
+      createdBy: userId || 'anonymous',
+      createdAt: new Date().toISOString(),
+      id: initialData?.id ?? ''
+    } as ASTFormData,
     currentStep: 1,
     errors: {},
     isDirty: false,
@@ -158,9 +160,9 @@ export function ASTProvider({
   });
 
   // ✅ HANDLERS ULTRA-STABLES - Références figées
-  const updateStepData = useCallback((section: string, data: any) => {
+  const updateStepData = useCallback(<K extends keyof ASTFormData>(section: K, data: ASTFormData[K]) => {
     console.log('🔥 Context Update:', { section, data, tenant: tenant.id });
-    
+
     dispatch({
       type: 'UPDATE_STEP_DATA',
       section,
@@ -171,7 +173,7 @@ export function ASTProvider({
     setTimeout(() => {
       saveToTenantDatabase(tenant.database, section, data, state.formData.astNumber);
     }, 1000);
-    
+
   }, [tenant.database, state.formData.astNumber]);
 
   const setCurrentStep = useCallback((step: number) => {
@@ -339,9 +341,9 @@ export function useAST() {
 
 // =================== API MULTI-TENANT AMÉLIORÉE ===================
 async function saveToTenantDatabase(
-  dbConfig: TenantConfig['database'], 
-  section: string, 
-  data: any,
+  dbConfig: TenantConfig['database'],
+  section: string,
+  data: ASTFormData[keyof ASTFormData] | ASTFormData,
   astNumber: string
 ) {
   try {


### PR DESCRIPTION
## Summary
- use `ASTFormData` in AST context state and actions
- make `updateStepData` type-safe for each form section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b5c0a711c83239caa351dd4ab63b4