### PR TITLE
chore: remove unused useRouter imports

### DIFF
--- a/app/[tenant]/ast/page.tsx
+++ b/app/[tenant]/ast/page.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import React, { useState, useCallback, useEffect } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams } from 'next/navigation';
 import ASTForm from '@/components/ASTForm';
 import { ASTFormData } from '../../types/astForm';
 
 export default function ASTPage() {
   const params = useParams();
-  const router = useRouter();
   const tenant = params?.tenant as string;
 
   const [formData, setFormData] = useState<ASTFormData>({

--- a/app/[tenant]/page.tsx
+++ b/app/[tenant]/page.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import React, { useState, useCallback, useEffect } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams } from 'next/navigation';
 import ASTForm from '@/components/ASTForm';
 import { ASTFormData } from '../types/astForm';
 
 export default function ASTPage() {
   const params = useParams();
-  const router = useRouter();
   const tenant = params?.tenant as string;
 
   const [formData, setFormData] = useState<ASTFormData>({


### PR DESCRIPTION
## Summary
- clean import statements by removing unused `useRouter` in tenant pages

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module '@/app/types/astForm' in components/ASTForm.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689b5c0b2b4c83239299cb415084e2a0