### PR TITLE
fix: correct ASTFormData import alias

### DIFF
--- a/components/ASTForm.tsx
+++ b/components/ASTForm.tsx
@@ -8,7 +8,7 @@ import {
   Plus, Trash2, Edit, Star, Wifi, WifiOff, Upload, Bell, Wrench, Wind,
   Droplets, Flame, Activity, Search, Filter, Hand, MessageSquare
 } from 'lucide-react';
-import { ASTFormData } from '@/app/types/astForm';
+import { ASTFormData } from '@/types/astForm';
 
 // =================== ✅ IMPORTS DES COMPOSANTS STEPS 1-6 (CONSERVÉS INTÉGRALEMENT) ===================
 import Step1ProjectInfo from '@/components/steps/Step1ProjectInfo';


### PR DESCRIPTION
## Summary
- fix incorrect ASTFormData import path

## Testing
- `npm run build` *(fails: Implicit conversion of a 'symbol' to a 'string')*

------
https://chatgpt.com/codex/tasks/task_e_689b5c14e1f48323af71c26f8b7f4688