### PR TITLE
feat: add typed data structures for initial steps

### DIFF
--- a/app/[tenant]/ast/nouveau/page.tsx
+++ b/app/[tenant]/ast/nouveau/page.tsx
@@ -17,18 +17,35 @@ export default function NouvellePage({ params }: PageProps) {
     astNumber: '',
     projectInfo: {
       client: '',
-      workLocation: '',
-      industry: '',
+      clientPhone: '',
+      clientRepresentative: '',
+      clientRepresentativePhone: '',
       projectNumber: '',
+      astClientNumber: '',
       date: '',
       time: '',
+      workLocation: '',
+      industry: '',
+      emergencyContact: '',
+      emergencyPhone: '',
       workDescription: '',
-      workerCount: 1,
-      lockoutPoints: []
+      workLocations: [],
+      lockoutPoints: [],
+      lockoutPhotos: []
     },
     equipment: {
+      list: [],
       selected: [],
-      custom: []
+      totalSelected: 0,
+      highPriority: 0,
+      categories: [],
+      inspectionStatus: {
+        total: 0,
+        verified: 0,
+        available: 0,
+        verificationRate: 0,
+        availabilityRate: 0
+      }
     },
     hazards: {
       selected: [],

--- a/app/[tenant]/ast/page.tsx
+++ b/app/[tenant]/ast/page.tsx
@@ -15,18 +15,35 @@ export default function ASTPage() {
     astNumber: '',
     projectInfo: {
       client: '',
-      workLocation: '',
-      industry: '',
+      clientPhone: '',
+      clientRepresentative: '',
+      clientRepresentativePhone: '',
       projectNumber: '',
+      astClientNumber: '',
       date: '',
       time: '',
+      workLocation: '',
+      industry: '',
+      emergencyContact: '',
+      emergencyPhone: '',
       workDescription: '',
-      workerCount: 1,
-      lockoutPoints: []
+      workLocations: [],
+      lockoutPoints: [],
+      lockoutPhotos: []
     },
     equipment: {
+      list: [],
       selected: [],
-      custom: []
+      totalSelected: 0,
+      highPriority: 0,
+      categories: [],
+      inspectionStatus: {
+        total: 0,
+        verified: 0,
+        available: 0,
+        verificationRate: 0,
+        availabilityRate: 0
+      }
     },
     hazards: {
       selected: [],

--- a/app/[tenant]/page.tsx
+++ b/app/[tenant]/page.tsx
@@ -15,18 +15,35 @@ export default function ASTPage() {
     astNumber: '',
     projectInfo: {
       client: '',
-      workLocation: '',
-      industry: '',
+      clientPhone: '',
+      clientRepresentative: '',
+      clientRepresentativePhone: '',
       projectNumber: '',
+      astClientNumber: '',
       date: '',
       time: '',
+      workLocation: '',
+      industry: '',
+      emergencyContact: '',
+      emergencyPhone: '',
       workDescription: '',
-      workerCount: 1,
-      lockoutPoints: []
+      workLocations: [],
+      lockoutPoints: [],
+      lockoutPhotos: []
     },
     equipment: {
+      list: [],
       selected: [],
-      custom: []
+      totalSelected: 0,
+      highPriority: 0,
+      categories: [],
+      inspectionStatus: {
+        total: 0,
+        verified: 0,
+        available: 0,
+        verificationRate: 0,
+        availabilityRate: 0
+      }
     },
     hazards: {
       selected: [],

--- a/app/types/astForm.ts
+++ b/app/types/astForm.ts
@@ -1,18 +1,104 @@
-export interface ProjectInfo {
-  client: string;
-  workLocation: string;
-  industry: string;
-  projectNumber: string;
-  date: string;
-  time: string;
-  workDescription: string;
-  workerCount: number;
-  lockoutPoints: string[];
+// =================== STEP 1 - PROJECT INFORMATION ===================
+
+export interface WorkLocation {
+  id: string;
+  name: string;
+  description: string;
+  zone: string;
+  building?: string;
+  floor?: string;
+  maxWorkersReached: number;
+  currentWorkers: number;
+  lockoutPoints: number;
+  isActive: boolean;
+  createdAt: string;
+  notes?: string;
+  estimatedDuration: string;
+  startTime?: string;
+  endTime?: string;
 }
 
-export interface EquipmentData {
-  selected: string[];
-  custom: string[];
+export interface LockoutPoint {
+  id: string;
+  energyType:
+    | 'electrical'
+    | 'mechanical'
+    | 'hydraulic'
+    | 'pneumatic'
+    | 'chemical'
+    | 'thermal'
+    | 'gravity';
+  equipmentName: string;
+  location: string;
+  lockType: string;
+  tagNumber: string;
+  isLocked: boolean;
+  verifiedBy: string;
+  verificationTime: string;
+  photos: string[];
+  notes: string;
+  completedProcedures: number[];
+  assignedLocation?: string;
+}
+
+export interface LockoutPhoto {
+  id: string;
+  url: string;
+  caption: string;
+  category:
+    | 'before_lockout'
+    | 'during_lockout'
+    | 'lockout_device'
+    | 'client_form'
+    | 'verification';
+  timestamp: string;
+  lockoutPointId?: string;
+}
+
+export interface Step1Data {
+  client: string;
+  clientPhone: string;
+  clientRepresentative: string;
+  clientRepresentativePhone: string;
+  projectNumber: string;
+  astClientNumber: string;
+  date: string;
+  time: string;
+  workLocation: string;
+  industry: string;
+  emergencyContact: string;
+  emergencyPhone: string;
+  workDescription: string;
+  workLocations: WorkLocation[];
+  lockoutPoints: LockoutPoint[];
+  lockoutPhotos: LockoutPhoto[];
+}
+
+// =================== STEP 2 - EQUIPMENT ===================
+
+export interface Step2EquipmentItem {
+  id: string;
+  name: string;
+  category: string;
+  required: boolean;
+  certification?: string;
+  priority?: 'high' | 'medium' | 'low';
+  icon: string;
+}
+
+export interface Step2Data {
+  list: Step2EquipmentItem[];
+  selected: Step2EquipmentItem[];
+  totalSelected: number;
+  highPriority: number;
+  categories: string[];
+  inspectionStatus: {
+    total: number;
+    verified: number;
+    available: number;
+    verificationRate: number;
+    availabilityRate: number;
+  };
 }
 
 export interface HazardsData {
@@ -36,8 +122,8 @@ export interface FinalizationData {
 export interface ASTFormData {
   id: string;
   astNumber: string;
-  projectInfo: ProjectInfo;
-  equipment: EquipmentData;
+  projectInfo: Step1Data;
+  equipment: Step2Data;
   hazards: HazardsData;
   permits: PermitsData;
   validation: ValidationData;

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -515,4 +515,12 @@ export type {
   ApiResponse as APIResponse
 } from './api';
 
-export type { ASTFormData } from './astForm';
+export type {
+  ASTFormData,
+  Step1Data,
+  Step2Data,
+  WorkLocation,
+  LockoutPoint,
+  LockoutPhoto,
+  Step2EquipmentItem
+} from './astForm';

--- a/components/ASTForm.tsx
+++ b/components/ASTForm.tsx
@@ -8,7 +8,7 @@ import {
   Plus, Trash2, Edit, Star, Wifi, WifiOff, Upload, Bell, Wrench, Wind,
   Droplets, Flame, Activity, Search, Filter, Hand, MessageSquare
 } from 'lucide-react';
-import { ASTFormData } from '@/app/types/astForm';
+import { ASTFormData } from '@/types/astForm';
 
 // =================== ✅ IMPORTS DES COMPOSANTS STEPS 1-6 (CONSERVÉS INTÉGRALEMENT) ===================
 import Step1ProjectInfo from '@/components/steps/Step1ProjectInfo';
@@ -282,7 +282,7 @@ export default function ASTForm<T extends ASTFormData = ASTFormData>({
   
   if (!stableHandlerRef.current) {
     stableHandlerRef.current = (section, data) => {
-      const updateKey = `${section}-${JSON.stringify(data).slice(0, 50)}`;
+      const updateKey = `${String(section)}-${JSON.stringify(data).slice(0, 50)}`;
       
       // ✅ ÉVITER LES DOUBLONS
       if (lastUpdateRef.current === updateKey) {
@@ -1168,13 +1168,16 @@ export default function ASTForm<T extends ASTFormData = ASTFormData>({
     const ultraStableHandler = stableHandlerRef.current!;
     
     // ✅ PROPS STABLES - MÉMORISÉS POUR ÉVITER RE-RENDERS
-    const stepProps = useMemo(() => ({
-      formData: stableFormDataRef.current,
-      language: currentLanguage,
-      tenant: tenant,
-      errors: {},
-      onDataChange: ultraStableHandler
-    }), [currentLanguage, tenant, ultraStableHandler]);
+    const stepProps: any = useMemo(
+      () => ({
+        formData: stableFormDataRef.current as ASTFormData,
+        language: currentLanguage,
+        tenant: tenant,
+        errors: {},
+        onDataChange: ultraStableHandler as (section: string, data: any) => void
+      }),
+      [currentLanguage, tenant, ultraStableHandler]
+    );
     
     console.log('🔥 StepContent render - Step:', currentStep, 'RenderCount:', renderCountRef.current);
     

--- a/components/steps/Step2Equipment.tsx
+++ b/components/steps/Step2Equipment.tsx
@@ -1,28 +1,23 @@
 "use client";
 
 import React, { useState } from 'react';
-import { 
-  Shield, Search, CheckCircle, HardHat, Eye, Wind, Hand, 
-  Zap, Activity, Star, AlertTriangle 
+import {
+  Shield, Search, CheckCircle, HardHat, Eye, Wind, Hand,
+  Zap, Activity, Star, AlertTriangle
 } from 'lucide-react';
+import type {
+  ASTFormData,
+  Step2Data,
+  Step2EquipmentItem
+} from '@/types/astForm';
 
 // =================== INTERFACES ===================
 interface Step2EquipmentProps {
-  formData: any;
-  onDataChange: (section: string, data: any) => void;
+  formData: ASTFormData;
+  onDataChange: (section: 'equipment', data: Step2Data) => void;
   language: 'fr' | 'en';
   tenant: string;
   errors?: any;
-}
-
-interface Equipment {
-  id: string;
-  name: string;
-  category: string;
-  required: boolean;
-  certification?: string;
-  priority?: 'high' | 'medium' | 'low';
-  icon: string;
 }
 
 // =================== SYSTÈME DE TRADUCTIONS COMPLET ===================
@@ -241,7 +236,7 @@ const translations = {
 };
 
 // =================== FONCTION POUR GÉNÉRER LA LISTE D'ÉQUIPEMENTS TRADUITE ===================
-const getEquipmentList = (language: 'fr' | 'en'): Equipment[] => {
+const getEquipmentList = (language: 'fr' | 'en'): Step2EquipmentItem[] => {
   const t = translations[language];
   
   return [
@@ -642,15 +637,15 @@ const Step2Equipment: React.FC<Step2EquipmentProps> = ({
   const [selectedCategory, setSelectedCategory] = useState('all');
   
   // Initialiser avec la liste complète des équipements traduits
-  const [equipment, setEquipment] = useState<Equipment[]>(() => {
+  const [equipment, setEquipment] = useState<Step2EquipmentItem[]>(() => {
     if (formData.equipment?.list && formData.equipment.list.length > 0) {
       // Si nous avons déjà des équipements sauvegardés, les utiliser mais mettre à jour les traductions
       const savedEquipment = formData.equipment.list;
       const translatedEquipment = getEquipmentList(language);
-      
+
       // Fusionner les données sauvegardées avec les nouvelles traductions
       return translatedEquipment.map(translatedItem => {
-        const savedItem = savedEquipment.find((saved: Equipment) => saved.id === translatedItem.id);
+        const savedItem = savedEquipment.find((saved: Step2EquipmentItem) => saved.id === translatedItem.id);
         return savedItem ? { ...translatedItem, required: savedItem.required } : translatedItem;
       });
     }
@@ -692,20 +687,20 @@ const Step2Equipment: React.FC<Step2EquipmentProps> = ({
   // =================== HANDLERS ===================
   
   const handleEquipmentToggle = (equipmentId: string) => {
-    const updatedEquipment = equipment.map(item => 
-      item.id === equipmentId 
+    const updatedEquipment = equipment.map(item =>
+      item.id === equipmentId
         ? { ...item, required: !item.required }
         : item
     );
-    
+
     setEquipment(updatedEquipment);
     updateFormData(updatedEquipment);
   };
 
-  const updateFormData = (updatedEquipment: Equipment[]) => {
+  const updateFormData = (updatedEquipment: Step2EquipmentItem[]) => {
     const selectedList = updatedEquipment.filter(eq => eq.required);
-    
-    const equipmentData = {
+
+    const equipmentData: Step2Data = {
       list: updatedEquipment,
       selected: selectedList,
       totalSelected: selectedList.length,
@@ -719,7 +714,7 @@ const Step2Equipment: React.FC<Step2EquipmentProps> = ({
         availabilityRate: 100
       }
     };
-    
+
     onDataChange('equipment', equipmentData);
   };
 
@@ -912,7 +907,7 @@ const Step2Equipment: React.FC<Step2EquipmentProps> = ({
   };
 
   // =================== COMPOSANT CARTE D'ÉQUIPEMENT ===================
-  const EquipmentCard = ({ item }: { item: Equipment }) => {
+  const EquipmentCard = ({ item }: { item: Step2EquipmentItem }) => {
     const isSelected = item.required;
     
     return (


### PR DESCRIPTION
## Summary
- add Step1Data and Step2Data interfaces to describe project info and equipment data
- type step components and ASTForm to use the new step-specific data structures
- initialize form pages with new typed sections

## Testing
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689b5c145e248323bd2aea5b6f0766d3