### PR TITLE
Ensure Prisma disconnects via finally block

### DIFF
--- a/app/api/db/init/route.test.ts
+++ b/app/api/db/init/route.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('next/server', () => ({
+  NextResponse: { json: (data: unknown, init?: unknown) => ({ data, init }) },
+}));
+
+describe('GET', () => {
+  it('disconnects after success', async () => {
+    vi.resetModules();
+    const disconnect = vi.fn();
+    const count = vi.fn().mockResolvedValue(0);
+    const upsert = vi.fn().mockResolvedValue({ companyName: 'X' });
+
+    vi.doMock('@/lib/prisma', () => ({
+      prisma: {
+        $connect: vi.fn(),
+        $disconnect: disconnect,
+        tenant: { count, upsert },
+      },
+    }));
+
+    const { GET } = await import('./route');
+    await GET();
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('disconnects after error', async () => {
+    vi.resetModules();
+    const disconnect = vi.fn();
+    const count = vi.fn().mockRejectedValue(new Error('fail'));
+
+    vi.doMock('@/lib/prisma', () => ({
+      prisma: {
+        $connect: vi.fn(),
+        $disconnect: disconnect,
+        tenant: { count, upsert: vi.fn() },
+      },
+    }));
+
+    const { GET } = await import('./route');
+    await GET();
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/api/db/init/route.ts
+++ b/app/api/db/init/route.ts
@@ -49,8 +49,6 @@ export async function GET() {
     // Recompter le nombre total de tenants après création/upsert
     const totalTenants = await prisma.tenant.count()
 
-    await prisma.$disconnect()
-
     return NextResponse.json({
       success: true,
       message: '🎉 Base de données connectée et tenants créés!',
@@ -80,5 +78,7 @@ export async function GET() {
       error: 'Unknown error',
       details: "Vérifiez les variables d'environnement Supabase"
     }, { status: 500 })
+  } finally {
+    await prisma.$disconnect()
   }
 }


### PR DESCRIPTION
## Summary
- move `prisma.$disconnect()` into a `finally` block so connections close on success or error
- add tests verifying disconnect runs after both successful and failed executions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b5d4936e48323ac0e8d1b0b1129be