### PR TITLE
docs: clarify symbol-safe updateKey

### DIFF
--- a/components/ASTForm.tsx
+++ b/components/ASTForm.tsx
@@ -282,8 +282,9 @@ export default function ASTForm<T extends ASTFormData = ASTFormData>({
   
   if (!stableHandlerRef.current) {
     stableHandlerRef.current = (section, data) => {
+      // Convert section (which may be a symbol) to string for a stable key
       const updateKey = `${String(section)}-${JSON.stringify(data).slice(0, 50)}`;
-      
+
       // ✅ ÉVITER LES DOUBLONS
       if (lastUpdateRef.current === updateKey) {
         console.log('🛡️ DOUBLON ÉVITÉ:', { section, updateKey });


### PR DESCRIPTION
## Summary
- document symbol-safe key conversion in AST form handler

## Testing
- `npm run build` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_689b5ff47ed48323ac069bf767fc8a6f