### PR TITLE
feat: centralize env validation

### DIFF
--- a/app/api/ast/route.ts
+++ b/app/api/ast/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { prisma } from '@/lib/prisma'
 import { z } from 'zod'
+import env from '@/lib/env'
 
 const requestSchema = z.object({
   tenantId: z.string(),
@@ -10,7 +11,7 @@ const requestSchema = z.object({
 
 export async function POST(request: NextRequest) {
   try {
-    const token = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET })
+    const token = await getToken({ req: request, secret: env.NEXTAUTH_SECRET })
     const userId = token?.sub
     if (!userId) {
       return NextResponse.json(
@@ -78,7 +79,7 @@ export async function POST(request: NextRequest) {
 
 export async function GET(request: NextRequest) {
   try {
-    const token = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET })
+    const token = await getToken({ req: request, secret: env.NEXTAUTH_SECRET })
     if (!token?.sub) {
       return NextResponse.json(
         { error: 'Authentication required' },

--- a/app/utils/documentGeneration.ts
+++ b/app/utils/documentGeneration.ts
@@ -3,6 +3,7 @@
 import { AST, ASTStatus } from '../types/ast';
 import { ComplianceReport } from './compliance';
 import { RiskLevel } from '../types/index';
+import env from '@/lib/env';
 
 // =================== INTERFACES NOTIFICATIONS ===================
 export interface NotificationTemplate {
@@ -552,7 +553,7 @@ export async function sendComplianceNotification(
   const variables = {
     complianceScore: complianceReport.overallScore,
     criticalActionsCount: complianceReport.criticalActions.length,
-    complianceReportUrl: `${process.env.BASE_URL}/compliance/${complianceReport.tenantId}`,
+    complianceReportUrl: `${env.BASE_URL}/compliance/${complianceReport.tenantId}`,
     generatedAt: complianceReport.generatedAt,
     nextReviewDate: complianceReport.nextReviewDate
   };
@@ -801,7 +802,7 @@ function prepareASTVariables(ast: AST, additionalData?: Record<string, any>): Re
     plannedStartDate: astAny.plannedStartDate || new Date().toISOString(),
     plannedEndDate: astAny.plannedEndDate || new Date().toISOString(),
     status: ast.status || 'DRAFT',
-    astUrl: `${process.env.BASE_URL || 'http://localhost:3000'}/ast/${ast.id}`,
+    astUrl: `${env.BASE_URL}/ast/${ast.id}`,
     ...additionalData
   };
 }

--- a/components/ASTContext.tsx
+++ b/components/ASTContext.tsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useContext, useReducer, useCallback, useRef, useState, useEffect } from 'react';
 import { ASTFormData } from '@/types/astForm';
+import env from '@/lib/env';
 
 // =================== INTERFACES MULTI-TENANT ===================
 export interface TenantConfig {
@@ -348,7 +349,7 @@ async function saveToTenantDatabase(
 ) {
   try {
     // 🚀 Mode development - simulation API
-    if (process.env.NODE_ENV === 'development') {
+    if (env.NODE_ENV === 'development') {
       console.log('💾 DEV - Sauvegarde simulée:', {
         tenant: dbConfig.schema,
         section,

--- a/components/steps/Step4Permits/ConfinedSpace/SafetyManager.tsx
+++ b/components/steps/Step4Permits/ConfinedSpace/SafetyManager.tsx
@@ -4,11 +4,12 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { createClient } from '@supabase/supabase-js';
+import env from '@/lib/env';
 
 // =================== CONFIGURATION SUPABASE ROBUSTE ===================
 const FALLBACK_URL = 'http://localhost:54321';
-const supabaseUrlEnv = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const supabaseUrlEnv = env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
 let supabase: any = null;
 let supabaseEnabled = false;

--- a/hooks/useGoogleMaps.ts
+++ b/hooks/useGoogleMaps.ts
@@ -1,5 +1,6 @@
 // hooks/useGoogleMaps.ts
 import { useState, useEffect } from 'react';
+import env from '@/lib/env';
 
 export interface Coordinates {
   lat: number;
@@ -26,7 +27,7 @@ export const useGoogleMaps = (config?: GoogleMapsConfig) => {
   const [error, setError] = useState<string | null>(null);
 
   const defaultConfig: GoogleMapsConfig = {
-    apiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || 'demo-key',
+    apiKey: env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || 'demo-key',
     libraries: ['places', 'geometry'],
     region: 'CA',
     language: 'fr',

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+// Define the schema for required environment variables
+export const envSchema = z.object({
+  DATABASE_URL: z.string().url(),
+  NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string(),
+  SUPABASE_SERVICE_ROLE_KEY: z.string(),
+  NEXTAUTH_SECRET: z.string(),
+  NEXTAUTH_URL: z.string().url(),
+  NEXT_PUBLIC_APP_NAME: z.string(),
+  NEXT_PUBLIC_DEFAULT_TENANT: z.string(),
+  WEATHER_API_KEY: z.string(),
+  NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: z.string().optional(),
+  BASE_URL: z.string().url().default('http://localhost:3000'),
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('production'),
+});
+
+// Parse and validate the environment variables on startup
+const parsed = envSchema.safeParse(process.env);
+if (!parsed.success) {
+  console.error('❌ Invalid environment variables', parsed.error.flatten().fieldErrors);
+  throw new Error('Missing or invalid environment variables');
+}
+
+export const env = parsed.data;
+export type Env = z.infer<typeof envSchema>;
+export default env;

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client'
+import env from '@/lib/env'
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined
@@ -6,4 +7,4 @@ const globalForPrisma = globalThis as unknown as {
 
 export const prisma = globalForPrisma.prisma ?? new PrismaClient()
 
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+if (env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,8 +1,9 @@
 import { createClient } from '@supabase/supabase-js'
+import env from '@/lib/env'
 
 const FALLBACK_URL = 'http://localhost:54321'
-const supabaseUrlEnv = process.env.NEXT_PUBLIC_SUPABASE_URL
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+const supabaseUrlEnv = env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseAnonKey = env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
 if (!supabaseAnonKey) {
   console.error('Missing NEXT_PUBLIC_SUPABASE_ANON_KEY. Set it in your .env.local file.')

--- a/lib/weatherApi.ts
+++ b/lib/weatherApi.ts
@@ -1,4 +1,5 @@
 import type { WeatherData } from '../hooks/useWeatherData';
+import env from '@/lib/env';
 
 const API_BASE = 'https://api.openweathermap.org/data/3.0/onecall';
 const DEFAULT_TIMEOUT = 5000;
@@ -9,7 +10,7 @@ const degToCompass = (deg: number): string => {
 };
 
 export async function getWeatherData(lat: number, lng: number): Promise<WeatherData> {
-  const apiKey = process.env.WEATHER_API_KEY;
+  const apiKey = env.WEATHER_API_KEY;
   if (!apiKey) {
     throw new Error('WEATHER_API_KEY is not defined');
   }


### PR DESCRIPTION
## Summary
- add zod-based env schema to validate required environment variables
- replace direct `process.env` usage with imported `env` helper
- use validated env values across supabase, API routes, hooks, and utilities

## Testing
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=anon-key SUPABASE_SERVICE_ROLE_KEY=service-role NEXTAUTH_SECRET=secret NEXTAUTH_URL=http://localhost:3000 NEXT_PUBLIC_APP_NAME=AST NEXT_PUBLIC_DEFAULT_TENANT=demo WEATHER_API_KEY=weatherkey npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b653b2d44832385869359ae770d75