### PR TITLE
chore: force dynamic db init route

### DIFF
--- a/app/api/db/init/route.ts
+++ b/app/api/db/init/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
+export const dynamic = 'force-dynamic'
+
 export async function GET() {
   try {
     console.log('🔄 Testing database connection...')


### PR DESCRIPTION
## Summary
- avoid DB init being executed at build by forcing dynamic route

## Testing
- `npm test`
- `npm run build` *(fails: Property 'selectedEquipment' does not exist on type 'ASTData')*


------
https://chatgpt.com/codex/tasks/task_e_689bbc3094d883239f28062266306535