### PR TITLE
feat: add optional lazy env validation

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,28 +1,63 @@
 import { z } from 'zod';
 
-// Define the schema for required environment variables
-export const envSchema = z.object({
-  DATABASE_URL: z.string().url(),
+const skipValidation = !!process.env.SKIP_ENV_VALIDATION;
+
+const clientSchema = z.object({
   NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string(),
+  NEXT_PUBLIC_APP_NAME: z.string(),
+  NEXT_PUBLIC_DEFAULT_TENANT: z.string(),
+  NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: z.string().optional(),
+});
+
+const serverSchema = z.object({
+  DATABASE_URL: z.string().url(),
   SUPABASE_SERVICE_ROLE_KEY: z.string(),
   NEXTAUTH_SECRET: z.string(),
   NEXTAUTH_URL: z.string().url(),
-  NEXT_PUBLIC_APP_NAME: z.string(),
-  NEXT_PUBLIC_DEFAULT_TENANT: z.string(),
   WEATHER_API_KEY: z.string(),
-  NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: z.string().optional(),
   BASE_URL: z.string().url().default('http://localhost:3000'),
   NODE_ENV: z.enum(['development', 'test', 'production']).default('production'),
 });
 
-// Parse and validate the environment variables on startup
-const parsed = envSchema.safeParse(process.env);
-if (!parsed.success) {
-  console.error('❌ Invalid environment variables', parsed.error.flatten().fieldErrors);
-  throw new Error('Missing or invalid environment variables');
+export type ClientEnv = z.infer<typeof clientSchema>;
+export type ServerEnv = z.infer<typeof serverSchema>;
+
+const clientEnv: ClientEnv = skipValidation
+  ? (process.env as unknown as ClientEnv)
+  : clientSchema.parse(process.env);
+
+let serverEnv: ServerEnv | null = null;
+const loadServerEnv = (): ServerEnv => {
+  if (serverEnv) return serverEnv;
+  if (skipValidation) {
+    serverEnv = {
+      BASE_URL: 'http://localhost:3000',
+      NODE_ENV: 'production',
+      ...process.env,
+    } as unknown as ServerEnv;
+    return serverEnv;
+  }
+  const parsed = serverSchema.safeParse(process.env);
+  if (!parsed.success) {
+    console.error('❌ Invalid environment variables', parsed.error.flatten().fieldErrors);
+    throw new Error('Missing or invalid environment variables');
+  }
+  serverEnv = parsed.data;
+  return serverEnv;
+};
+
+export const env: ClientEnv & ServerEnv = clientEnv as ClientEnv & ServerEnv;
+for (const key of Object.keys(serverSchema.shape)) {
+  Object.defineProperty(env, key, {
+    enumerable: true,
+    get() {
+      return loadServerEnv()[key as keyof ServerEnv];
+    },
+  });
 }
 
-export const env = parsed.data;
-export type Env = z.infer<typeof envSchema>;
+export const getServerEnv = loadServerEnv;
+export type Env = ClientEnv & ServerEnv;
 export default env;
+


### PR DESCRIPTION
## Summary
- allow SKIP_ENV_VALIDATION flag to bypass environment checks
- lazily validate server-only environment variables on access

## Testing
- `SKIP_ENV_VALIDATION=1 npm test`
- `SKIP_ENV_VALIDATION=1 npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689bbc37e05c8323be04d93bb10f9498