### PR TITLE
refactor: require env vars for external services

### DIFF
--- a/components/steps/Step4Permits/ConfinedSpace/SafetyManager.tsx
+++ b/components/steps/Step4Permits/ConfinedSpace/SafetyManager.tsx
@@ -6,23 +6,28 @@ import { persist } from 'zustand/middleware';
 import { createClient } from '@supabase/supabase-js';
 
 // =================== CONFIGURATION SUPABASE ROBUSTE ===================
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://your-project.supabase.co';
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'your-anon-key';
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
 let supabase: any = null;
 let supabaseEnabled = false;
 
-try {
-  if (supabaseUrl && supabaseKey && supabaseUrl !== 'https://your-project.supabase.co') {
+if (!supabaseUrl || !supabaseKey) {
+  console.error(
+    'SafetyManager: Missing Supabase environment variables. Define NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.'
+  );
+} else if (process.env.NODE_ENV !== 'test') {
+  try {
     supabase = createClient(supabaseUrl, supabaseKey);
     supabaseEnabled = true;
     console.log('✅ SafetyManager: Supabase configuré');
-  } else {
-    console.log('📝 SafetyManager: Utilisation du localStorage');
+  } catch (error) {
+    console.error('⚠️ SafetyManager: Supabase initialisation échouée', error);
   }
-} catch (error) {
-  console.log('⚠️ SafetyManager: Supabase non configuré, utilisation du localStorage');
-  supabaseEnabled = false;
+}
+
+if (!supabaseEnabled) {
+  console.log('📝 SafetyManager: Utilisation du localStorage');
 }
 
 // =================== TYPES UNIVERSELS ===================

--- a/hooks/useGoogleMaps.ts
+++ b/hooks/useGoogleMaps.ts
@@ -25,8 +25,10 @@ export const useGoogleMaps = (config?: GoogleMapsConfig) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+
   const defaultConfig: GoogleMapsConfig = {
-    apiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || 'demo-key',
+    apiKey,
     libraries: ['places', 'geometry'],
     region: 'CA',
     language: 'fr',
@@ -35,6 +37,11 @@ export const useGoogleMaps = (config?: GoogleMapsConfig) => {
 
   useEffect(() => {
     const loadGoogleMaps = async () => {
+      if (!apiKey) {
+        setError('NEXT_PUBLIC_GOOGLE_MAPS_API_KEY is not defined');
+        return;
+      }
+
       // Vérifier si Google Maps est déjà chargé
       if (typeof window !== 'undefined' && (window as any).google?.maps) {
         setIsLoaded(true);
@@ -53,8 +60,8 @@ export const useGoogleMaps = (config?: GoogleMapsConfig) => {
         if (typeof document !== 'undefined') {
           const script = document.createElement('script');
           const libraries = defaultConfig.libraries?.join(',') || 'places,geometry';
-          
-          script.src = `https://maps.googleapis.com/maps/api/js?key=${defaultConfig.apiKey}&libraries=${libraries}&region=${defaultConfig.region}&language=${defaultConfig.language}`;
+
+          script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=${libraries}&region=${defaultConfig.region}&language=${defaultConfig.language}`;
           script.async = true;
           script.defer = true;
 
@@ -76,7 +83,9 @@ export const useGoogleMaps = (config?: GoogleMapsConfig) => {
       }
     };
 
-    loadGoogleMaps();
+    if (process.env.NODE_ENV !== 'test') {
+      loadGoogleMaps();
+    }
   }, []);
 
   // Fonction pour géocoder une adresse


### PR DESCRIPTION
## Summary
- enforce presence of `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` before loading Google Maps and surface errors when missing
- ensure Supabase only initializes when `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are set
- guard service setup during test runs

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689ab56378d08323b04bc09c995f3504