### PR TITLE
Add AST form schema and validate requests

### DIFF
--- a/app/api/ast/route.ts
+++ b/app/api/ast/route.ts
@@ -2,10 +2,11 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { prisma } from '@/lib/prisma'
 import { z } from 'zod'
+import { ASTFormData } from '@/types/astFormSchema'
 
 const requestSchema = z.object({
   tenantId: z.string(),
-  formData: z.any()
+  formData: ASTFormData
 })
 
 export async function POST(request: NextRequest) {
@@ -23,7 +24,7 @@ export async function POST(request: NextRequest) {
     const parsed = requestSchema.safeParse(body)
     if (!parsed.success) {
       return NextResponse.json(
-        { success: false, error: 'Invalid request body' },
+        { success: false, error: parsed.error.flatten() },
         { status: 400 }
       )
     }

--- a/app/types/astFormSchema.ts
+++ b/app/types/astFormSchema.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod'
+
+export const ASTFormData = z.object({
+  projectNumber: z.string().optional(),
+  client: z.string().optional(),
+  workLocation: z.string().optional(),
+  clientRep: z.string(),
+  emergencyNumber: z.string(),
+  astClientNumber: z.string().optional(),
+  workDescription: z.string().optional(),
+  datetime: z.string(),
+  language: z.enum(['fr', 'en']),
+  teamDiscussion: z.any(),
+  isolation: z.any(),
+  hazards: z.any(),
+  controlMeasures: z.any(),
+  workers: z.any(),
+  photos: z.any()
+})
+
+export type ASTFormDataType = z.infer<typeof ASTFormData>


### PR DESCRIPTION
## Summary
- add Zod schema for AST form data
- use schema in AST API route and validate requests

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b653ec7088323b5ce11b6cde0f707