### PR TITLE
Default NODE_ENV to development

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -13,7 +13,8 @@ export const envSchema = z.object({
   WEATHER_API_KEY: z.string(),
   NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: z.string().optional(),
   BASE_URL: z.string().url().default('http://localhost:3000'),
-  NODE_ENV: z.enum(['development', 'test', 'production']).default('production'),
+  // Default to development unless explicitly set to production
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
 });
 
 // Parse and validate the environment variables on startup


### PR DESCRIPTION
## Summary
- default NODE_ENV to `development` unless explicitly set

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_689bbc2e42ac8323b97f9a41ff12e4a3