### PR TITLE
feat: expose selected equipment on AST data

### DIFF
--- a/components/steps/Step6Finalization.tsx
+++ b/components/steps/Step6Finalization.tsx
@@ -82,6 +82,10 @@ interface ASTData {
   projectNumber?: string;
   workLocation?: string;
   date?: string;
+  selectedEquipment?: string[];
+  selectedHazards?: string[];
+  selectedPermits?: string[];
+  teamMembers?: string[];
   
   // Step 1 - Informations projet
   projectInfo: {
@@ -617,7 +621,11 @@ function Step6Finalization({
       createdAt: formData?.createdAt || new Date().toISOString(),
       updatedAt: new Date().toISOString(),
       status: formData?.status || 'draft',
-      
+      selectedEquipment: formData?.selectedEquipment,
+      selectedHazards: formData?.selectedHazards,
+      selectedPermits: formData?.selectedPermits,
+      teamMembers: formData?.teamMembers,
+
       // ✅ Step 1 - Informations projet (récupérées de ASTForm)
       projectInfo: {
         client: formData?.projectInfo?.client || 'Non spécifié',

--- a/hooks/useFormValidation.ts
+++ b/hooks/useFormValidation.ts
@@ -360,7 +360,7 @@ export const useASTFormValidation = (initialData: ASTFormData) => {
       required: true,
       custom: (value) => {
         if (!value) return false;
-        const startDate = new Date(value);
+        const startDate = new Date(value as string);
         const today = new Date();
         today.setHours(0, 0, 0, 0);
         if (startDate < today) {
@@ -412,7 +412,7 @@ export const useASTFormValidation = (initialData: ASTFormData) => {
     }
   };
 
-  return useFormValidation(initialData, validationSchema, {
+  return useFormValidation(initialData as unknown as Record<string, unknown>, validationSchema, {
     validateOnChange: true,
     validateOnBlur: true,
     revalidateOnSubmit: true

--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -197,6 +197,10 @@ export const useLocalStorage = <T>(
 // Interface pour les types AST
 interface ASTData {
   id?: string;
+  selectedEquipment?: string[];
+  selectedHazards?: string[];
+  selectedPermits?: string[];
+  teamMembers?: string[];
   projectInfo?: {
     projectName?: string;
     client?: string;


### PR DESCRIPTION
## Summary
- expand ASTData with optional arrays for selected equipment, hazards, permits and team members
- populate these fields when extracting AST data
- align localStorage and form validation utilities with updated types

## Testing
- `npm test`
- `npm run build` *(fails: Type error in hooks/useGoogleMaps.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689bc433a3148323a2b15d0910206e47