### PR TITLE
feat: manage Prisma connection with singleton client

### DIFF
--- a/app/api/db/init/route.test.ts
+++ b/app/api/db/init/route.test.ts
@@ -1,44 +1,42 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest'
 
 vi.mock('next/server', () => ({
   NextResponse: { json: (data: unknown, init?: unknown) => ({ data, init }) },
-}));
+}))
 
 describe('GET', () => {
-  it('disconnects after success', async () => {
-    vi.resetModules();
-    const disconnect = vi.fn();
-    const count = vi.fn().mockResolvedValue(0);
-    const upsert = vi.fn().mockResolvedValue({ companyName: 'X' });
+  it('returns tenants after initialization', async () => {
+    vi.resetModules()
+    const count = vi.fn().mockResolvedValueOnce(0).mockResolvedValueOnce(3)
+    const upsert = vi.fn().mockResolvedValue({ companyName: 'X' })
 
     vi.doMock('@/lib/prisma', () => ({
       prisma: {
-        $connect: vi.fn(),
-        $disconnect: disconnect,
         tenant: { count, upsert },
       },
-    }));
+    }))
 
-    const { GET } = await import('./route');
-    await GET();
-    expect(disconnect).toHaveBeenCalledTimes(1);
-  });
+    const { GET } = await import('./route')
+    const res = await GET()
 
-  it('disconnects after error', async () => {
-    vi.resetModules();
-    const disconnect = vi.fn();
-    const count = vi.fn().mockRejectedValue(new Error('fail'));
+    expect(count).toHaveBeenCalledTimes(2)
+    expect(upsert).toHaveBeenCalledTimes(3)
+    expect(res.data.success).toBe(true)
+  })
+
+  it('handles errors gracefully', async () => {
+    vi.resetModules()
+    const count = vi.fn().mockRejectedValue(new Error('fail'))
 
     vi.doMock('@/lib/prisma', () => ({
       prisma: {
-        $connect: vi.fn(),
-        $disconnect: disconnect,
         tenant: { count, upsert: vi.fn() },
       },
-    }));
+    }))
 
-    const { GET } = await import('./route');
-    await GET();
-    expect(disconnect).toHaveBeenCalledTimes(1);
-  });
-});
+    const { GET } = await import('./route')
+    const res = await GET()
+
+    expect(res.data.success).toBe(false)
+  })
+})

--- a/app/api/db/init/route.ts
+++ b/app/api/db/init/route.ts
@@ -5,12 +5,9 @@ export async function GET() {
   try {
     console.log('🔄 Testing database connection...')
 
-    // Test de connexion à la base et création des tenants de démonstration
-    await prisma.$connect()
-    console.log('✅ Connected to database')
-
-    // Vérifier combien de tenants existent déjà
+    // Exécuter une première requête pour établir la connexion si nécessaire
     const initialTenantCount = await prisma.tenant.count()
+    console.log('✅ Connected to database')
     console.log('📊 Existing tenants:', initialTenantCount)
 
     // Créer tenant démo seulement s'il n'existe pas
@@ -78,7 +75,5 @@ export async function GET() {
       error: 'Unknown error',
       details: "Vérifiez les variables d'environnement Supabase"
     }, { status: 500 })
-  } finally {
-    await prisma.$disconnect()
   }
 }

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -8,3 +8,11 @@ const globalForPrisma = globalThis as unknown as {
 export const prisma = globalForPrisma.prisma ?? new PrismaClient()
 
 if (env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+
+// Ensure a single client manages its own connection lifecycle
+prisma.$connect()
+prisma.$on('beforeExit', async () => {
+  await prisma.$disconnect()
+})
+
+export default prisma


### PR DESCRIPTION
## Summary
- expose a singleton Prisma client that handles its own connection lifecycle
- simplify DB init route to rely on Prisma's implicit connection
- adjust route tests to assert query usage instead of manual disconnects

## Testing
- `npm test`
- `npx ts-node -e "import { prisma } from './lib/prisma'; prisma.tenant.count().then(r => {console.log('count', r);}).catch(e => {console.error('error', e.message);}).finally(() => process.exit());"` *(fails: needs ts-node package)*

------
https://chatgpt.com/codex/tasks/task_e_689bc662d58083239577a1c8c8358ae5