### PR TITLE
refactor: move translations type

### DIFF
--- a/components/steps/Step6Finalization.tsx
+++ b/components/steps/Step6Finalization.tsx
@@ -504,10 +504,12 @@ const translations = {
   }
 };
 
+export type Translations = typeof translations['fr'];
+
 // =================== FONCTION PRINCIPALE STEP6 ===================
-function Step6Finalization({ 
+function Step6Finalization({
   formData,
-  onDataChange, 
+  onDataChange,
   language = 'fr',
   tenant 
 }: FinalizationStepProps) {
@@ -903,8 +905,6 @@ function Step6Finalization({
       if (typeof currentValue === 'boolean') {
         newValue = !currentValue;
 }
-
-export type Translations = typeof translations['fr'];
       const updatedData = {
         ...finalizationData,
         documentGeneration: {


### PR DESCRIPTION
## Summary
- move `Translations` type to top-level scope in Step6Finalization
- remove stray export from toggleDocumentOption handler

## Testing
- `npm run build` *(fails: Argument of type '() => EntryRegistryData | ...' not assignable to parameter of type 'EntryRegistryData | (() => EntryRegistryData)' in components/steps/Step4Permits/ConfinedSpace/EntryRegistry.tsx:196:81)*

------
https://chatgpt.com/codex/tasks/task_e_689bcb2c3a0c8323ab1b539cecf07a9f