### PR TITLE
chore: provide default entry registry data

### DIFF
--- a/components/steps/Step4Permits/ConfinedSpace/EntryRegistry.tsx
+++ b/components/steps/Step4Permits/ConfinedSpace/EntryRegistry.tsx
@@ -193,27 +193,25 @@ const EntryRegistry: React.FC<ConfinedSpaceComponentProps> = ({
   onValidationChange
 }) => {
   // ✅ Derive registry data directly from SafetyManager store
-  const [entryRegistryData, setEntryRegistryData] = useState<EntryRegistryData>(() => {
-    if (safetyManager?.currentPermit?.entryRegistry) {
-      return safetyManager.currentPermit.entryRegistry;
-    }
-    return {
-      personnel: [],
-      entryLog: [],
-      entryLogs: [],
-      activeEntrants: [],
-      maxOccupancy: 3,
-      communicationProtocol: {
-        type: 'radio',
-        checkInterval: 0
-      },
-      lastUpdated: new Date().toISOString(),
-      currentOccupancy: 0,
-      attendantPresent: false,
-      communicationSystemActive: false,
-      emergencyContactsNotified: false
-    };
-  });
+  const [entryRegistryData, setEntryRegistryData] = useState<EntryRegistryData>(
+    () =>
+      safetyManager?.currentPermit?.entryRegistry ?? {
+        personnel: [],
+        entryLog: [],
+        entryLogs: [],
+        activeEntrants: [],
+        maxOccupancy: 3,
+        communicationProtocol: {
+          type: 'radio',
+          checkInterval: 15,
+        },
+        lastUpdated: new Date().toISOString(),
+        currentOccupancy: 0,
+        attendantPresent: false,
+        communicationSystemActive: false,
+        emergencyContactsNotified: false,
+      }
+  );
 
   // Subscribe to store updates so changes reflect immediately
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure entry registry state initializes all required fields with defaults

## Testing
- `npm run build` *(fails: Type error in useGoogleMaps.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689bcd8625e48323b818a8770bcb80b3