### PR TITLE
Handle null geocoder results

### DIFF
--- a/hooks/useGoogleMaps.ts
+++ b/hooks/useGoogleMaps.ts
@@ -99,7 +99,10 @@ export const useGoogleMaps = (config?: GoogleMapsConfig) => {
       
       geocoder.geocode(
         { address, region: defaultConfig.region },
-        (results: google.maps.GeocoderResult[], status: google.maps.GeocoderStatus) => {
+        (
+          results: google.maps.GeocoderResult[] | null,
+          status: google.maps.GeocoderStatus
+        ) => {
           if (status === 'OK' && results && results[0]) {
             const result = results[0];
             const location = result.geometry.location;
@@ -137,7 +140,10 @@ export const useGoogleMaps = (config?: GoogleMapsConfig) => {
       
       geocoder.geocode(
         { location: latLng },
-        (results: google.maps.GeocoderResult[], status: google.maps.GeocoderStatus) => {
+        (
+          results: google.maps.GeocoderResult[] | null,
+          status: google.maps.GeocoderStatus
+        ) => {
           if (status === 'OK' && results && results[0]) {
             const result = results[0];
             const location = result.geometry.location;


### PR DESCRIPTION
## Summary
- allow null geocode results in Google Maps hook

## Testing
- `npm run build` *(fails: Type error: Type 'string | undefined' is not assignable to type 'string' in hooks/useLocalStorage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689bd0778d40832394fa478a896202a8