### PR TITLE
fix: ensure recent project id

### DIFF
--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -285,6 +285,10 @@ export const useASTLocalStorage = () => {
 
   // Fonction pour ajouter aux projets récents
   const addToRecentProjects = useCallback((project: ASTData) => {
+    if (!project.id) {
+      project.id = `project_${Date.now()}`;
+    }
+
     const recentProject: RecentProject = {
       id: project.id,
       title: project.projectInfo?.projectName || 'Projet sans titre',


### PR DESCRIPTION
## Summary
- add fallback to generate project id when adding recent projects

## Testing
- `npm run build` *(fails: 'NODE_ENV' is specified more than once in lib/env.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689bd3440c7883238a9400004099211a