### PR TITLE
refactor recent projects id handling

### DIFF
--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -285,19 +285,17 @@ export const useASTLocalStorage = () => {
 
   // Fonction pour ajouter aux projets récents
   const addToRecentProjects = useCallback((project: ASTData) => {
-    if (!project.id) {
-      project.id = `project_${Date.now()}`;
-    }
+    const id = project.id ?? `project_${Date.now()}`;
 
     const recentProject: RecentProject = {
-      id: project.id,
+      id,
       title: project.projectInfo?.projectName || 'Projet sans titre',
       client: project.projectInfo?.client || 'Client inconnu',
       lastAccessed: new Date().toISOString()
     };
 
     setRecentProjects((prevRecent: RecentProject[]) => {
-      const filtered = prevRecent.filter(p => p.id !== project.id);
+      const filtered = prevRecent.filter(p => p.id !== id);
       return [recentProject, ...filtered].slice(0, 10); // Garder max 10 projets récents
     });
   }, [setRecentProjects]);


### PR DESCRIPTION
## Summary
- avoid mutating project ID when adding to recent projects by using local `id`

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive configuration)*
- `NEXT_DISABLE_ESLINT=1 NEXT_SKIP_TS_CHECK=1 npm run build` *(fails: lib/env.ts Type error 'NODE_ENV' is specified more than once)*

------
https://chatgpt.com/codex/tasks/task_e_689bd4f035008323ab73a149e5ff922b