### PR TITLE
Refactor env handling and fix build errors

### DIFF
--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -286,7 +286,7 @@ export const useASTLocalStorage = () => {
   // Fonction pour ajouter aux projets récents
   const addToRecentProjects = useCallback((project: ASTData) => {
     const recentProject: RecentProject = {
-      id: project.id,
+      id: project.id || `project_${Date.now()}`,
       title: project.projectInfo?.projectName || 'Projet sans titre',
       client: project.projectInfo?.client || 'Client inconnu',
       lastAccessed: new Date().toISOString()

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -25,7 +25,7 @@ export type ClientEnv = z.infer<typeof clientSchema>;
 export type ServerEnv = z.infer<typeof serverSchema>;
 
 const clientEnv: ClientEnv = skipValidation
-  ? (process.env as unknown as ClientEnv)
+  ? ({ ...process.env } as unknown as ClientEnv)
   : clientSchema.parse(process.env);
 
 let serverEnv: ServerEnv | null = null;
@@ -33,9 +33,9 @@ const loadServerEnv = (): ServerEnv => {
   if (serverEnv) return serverEnv;
   if (skipValidation) {
     serverEnv = {
-      BASE_URL: 'http://localhost:3000',
-      NODE_ENV: 'production',
       ...process.env,
+      BASE_URL: process.env.BASE_URL ?? 'http://localhost:3000',
+      NODE_ENV: process.env.NODE_ENV ?? 'development',
     } as unknown as ServerEnv;
     return serverEnv;
   }

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -10,8 +10,7 @@ export const prisma = globalForPrisma.prisma ?? new PrismaClient()
 if (env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
 
 // Ensure a single client manages its own connection lifecycle
-prisma.$connect()
-prisma.$on('beforeExit', async () => {
+process.on('beforeExit', async () => {
   await prisma.$disconnect()
 })
 


### PR DESCRIPTION
## Summary
- ensure server env spreads process.env before defaulting BASE_URL and NODE_ENV
- clone process.env when skipping env validation to avoid descriptor errors
- stabilize RecentProject IDs and simplify Prisma client lifecycle

## Testing
- `SKIP_ENV_VALIDATION=1 DATABASE_URL=postgresql://user:pass@localhost:5432/db npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689bd4e68d7c8323a4f140cc31997e81