### PR TITLE
fix: remove merge leftovers in useLocalStorage

### DIFF
--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -285,6 +285,7 @@ export const useASTLocalStorage = () => {
 
   // Fonction pour ajouter aux projets récents
   const addToRecentProjects = useCallback((project: ASTData) => {
+    // Compute a stable identifier without mutating the incoming project
     const id = project.id ?? `project_${Date.now()}`;
 
     const recentProject: RecentProject = {


### PR DESCRIPTION
## Summary
- clarify comment for computed id in `addToRecentProjects`

## Testing
- `npm run lint` (fails: ESLint setup prompt)
- `NEXT_DISABLE_ESLINT=1 npm run build` (fails: NODE_ENV specified more than once)


------
https://chatgpt.com/codex/tasks/task_e_689bd8b926908323b795bee4a7942669