### PR TITLE
fix: avoid duplicate NODE_ENV

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -34,7 +34,6 @@ const loadServerEnv = (): ServerEnv => {
   if (skipValidation) {
     serverEnv = {
       BASE_URL: 'http://localhost:3000',
-      NODE_ENV: 'production',
       ...process.env,
     } as unknown as ServerEnv;
     return serverEnv;

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -11,7 +11,7 @@ if (env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
 
 // Ensure a single client manages its own connection lifecycle
 prisma.$connect()
-prisma.$on('beforeExit', async () => {
+process.on('beforeExit', async () => {
   await prisma.$disconnect()
 })
 


### PR DESCRIPTION
## Summary
- rely on existing NODE_ENV from `process.env` when skipping env validation
- replace Prisma `$on('beforeExit')` with `process.on('beforeExit')`

## Testing
- `NEXT_PUBLIC_SUPABASE_URL=https://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=anon NEXT_PUBLIC_APP_NAME=test NEXT_PUBLIC_DEFAULT_TENANT=tenant DATABASE_URL=postgresql://localhost:5432/db SUPABASE_SERVICE_ROLE_KEY=role NEXTAUTH_SECRET=secret NEXTAUTH_URL=https://example.com WEATHER_API_KEY=key npm run build` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_689bdb1700148323b75c32d66389abe1