### PR TITLE
refactor: lazy prisma client for Next.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ npm test
 ```
 
 
+## Prisma Client
+
+This project uses Prisma for database access. The Prisma Client instance is
+cached on `globalThis` during development to prevent multiple instances from
+being created on hot reloads. The client connects lazily when a query is run,
+so you don't need to manually call `$connect` or handle disconnections. This
+pattern is the recommended approach when using Prisma with Next.js.
+
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,6 +1,8 @@
 import { PrismaClient } from '@prisma/client'
 import env from '@/lib/env'
 
+// Cache Prisma Client instance on `globalThis` to avoid re-instantiation
+// during development hot reloads. Prisma connects lazily on first use.
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined
 }
@@ -8,11 +10,5 @@ const globalForPrisma = globalThis as unknown as {
 export const prisma = globalForPrisma.prisma ?? new PrismaClient()
 
 if (env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
-
-// Ensure a single client manages its own connection lifecycle
-prisma.$connect()
-process.on('beforeExit', async () => {
-  await prisma.$disconnect()
-})
 
 export default prisma


### PR DESCRIPTION
## Summary
- remove manual Prisma connect/disconnect
- export singleton Prisma Client with `globalThis` caching
- document Prisma client usage in Next.js

## Testing
- `SKIP_ENV_VALIDATION=1 npm test`
- `SKIP_ENV_VALIDATION=1 DATABASE_URL=postgresql://user:pass@localhost:5432/db npm run build` *(fails: process.env does not accept accessor descriptor)*

------
https://chatgpt.com/codex/tasks/task_e_689bf1b06ca48323bdf05700e73172d1