### PR TITLE
refactor: debounce AST save

### DIFF
--- a/app/[tenant]/page.tsx
+++ b/app/[tenant]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { useParams } from 'next/navigation';
 import ASTForm from '@/components/ASTForm';
 import { ASTFormData } from '../types/astForm';
@@ -99,22 +99,20 @@ export default function ASTPage() {
     loadData();
   }, [tenant]);
 
-  const handleDataChange = useCallback(async <K extends keyof ASTFormData>(section: K, data: ASTFormData[K]) => {
-    setSaving(true);
+  const saveTimeout = useRef<NodeJS.Timeout | null>(null);
 
-    setFormData(prev => {
-      const newData: ASTFormData = {
-        ...prev,
-        [section]: data,
-        updatedAt: new Date().toISOString()
-      };
-      
-      setTimeout(async () => {
+  const debouncedSave = useCallback(
+    (data: ASTFormData) => {
+      if (saveTimeout.current) {
+        clearTimeout(saveTimeout.current);
+      }
+
+      saveTimeout.current = setTimeout(async () => {
         try {
-          await fetch(`/api/${tenant}/ast/save`, {
+          await fetch('/api/ast', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(newData)
+            body: JSON.stringify({ tenantId: tenant, formData: data })
           });
         } catch (err) {
           console.error('Erreur sauvegarde:', err);
@@ -122,10 +120,36 @@ export default function ASTPage() {
           setSaving(false);
         }
       }, 500);
-      
-      return newData;
-    });
-  }, [tenant]);
+    },
+    [tenant]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (saveTimeout.current) {
+        clearTimeout(saveTimeout.current);
+      }
+    };
+  }, []);
+
+  const handleDataChange = useCallback(
+    <K extends keyof ASTFormData>(section: K, data: ASTFormData[K]) => {
+      setSaving(true);
+
+      setFormData(prev => {
+        const newData: ASTFormData = {
+          ...prev,
+          [section]: data,
+          updatedAt: new Date().toISOString()
+        };
+
+        debouncedSave(newData);
+
+        return newData;
+      });
+    },
+    [debouncedSave]
+  );
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
- replace inline setTimeout logic with reusable debounced save in AST edit pages
- clear pending saves on unmount to avoid stale requests
- target the existing `/api/ast` endpoint for persisted data

## Testing
- `npm test`
- `curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:3001/api/ast -H 'Content-Type: application/json' -d '{"tenantId":"test","formData":{}}'`


------
https://chatgpt.com/codex/tasks/task_e_689bf1afc54083239c2c67b842c6d904