### PR TITLE
feat: add tenant AST API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ To execute the unit test suite, run:
 npm test
 ```
 
+## AST API
+
+Tenant specific endpoints are available under `api/[tenant]/ast` and require an
+authenticated user belonging to the tenant. Main routes include:
+
+- `GET /api/[tenant]/ast` – list AST forms for the tenant
+- `POST /api/[tenant]/ast` – create a new AST form
+- `GET /api/[tenant]/ast/[id]` – fetch a specific AST form
+- `POST /api/[tenant]/ast/save` – upsert an AST form draft
+
+All requests validate that the current user has access to the tenant before
+returning data.
+
 
 ## Learn More
 

--- a/app/api/[tenant]/ast/[id]/route.ts
+++ b/app/api/[tenant]/ast/[id]/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getToken } from 'next-auth/jwt'
+import { prisma } from '@/lib/prisma'
+import env from '@/lib/env'
+
+async function ensureUser(request: NextRequest, tenantSubdomain: string) {
+  const token = await getToken({ req: request, secret: env.NEXTAUTH_SECRET })
+  if (!token?.sub) {
+    return { error: NextResponse.json({ error: 'Authentication required' }, { status: 401 }) }
+  }
+
+  const tenant = await prisma.tenant.findUnique({ where: { subdomain: tenantSubdomain } })
+  if (!tenant) {
+    return { error: NextResponse.json({ error: 'Tenant not found' }, { status: 404 }) }
+  }
+
+  const user = await prisma.user.findUnique({ where: { id: token.sub } })
+  if (!user || user.tenantId !== tenant.id) {
+    return { error: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+
+  return { tenant }
+}
+
+export async function GET(request: NextRequest, { params }: { params: { tenant: string; id: string } }) {
+  const auth = await ensureUser(request, params.tenant)
+  if ('error' in auth) return auth.error
+  try {
+    const astForm = await prisma.aSTForm.findFirst({
+      where: { id: params.id, tenantId: auth.tenant.id }
+    })
+    if (!astForm) {
+      return NextResponse.json({ error: 'AST not found' }, { status: 404 })
+    }
+    return NextResponse.json(astForm)
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'An unexpected error occurred'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/api/[tenant]/ast/route.test.ts
+++ b/app/api/[tenant]/ast/route.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('next/server', () => ({
+  NextResponse: { json: (data: unknown, init?: any) => ({ data, init }) }
+}))
+
+vi.mock('next-auth/jwt', () => ({
+  getToken: vi.fn()
+}))
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: { tenant: {}, user: {}, aSTForm: {} }
+}))
+
+vi.mock('@/lib/env', () => ({
+  default: { NEXTAUTH_SECRET: 'test' }
+}))
+
+describe('GET /api/[tenant]/ast', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const { getToken } = await import('next-auth/jwt')
+    ;(getToken as any).mockResolvedValue(null)
+
+    const { GET } = await import('./route')
+    const res = await GET({} as any, { params: { tenant: 'demo' } })
+
+    expect(res.init.status).toBe(401)
+  })
+})

--- a/app/api/[tenant]/ast/route.ts
+++ b/app/api/[tenant]/ast/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getToken } from 'next-auth/jwt'
+import { prisma } from '@/lib/prisma'
+import env from '@/lib/env'
+import { z } from 'zod'
+
+const bodySchema = z.object({
+  formData: z.any()
+})
+
+async function ensureUser(request: NextRequest, tenantSubdomain: string) {
+  const token = await getToken({ req: request, secret: env.NEXTAUTH_SECRET })
+  if (!token?.sub) {
+    return { error: NextResponse.json({ error: 'Authentication required' }, { status: 401 }) }
+  }
+
+  const tenant = await prisma.tenant.findUnique({ where: { subdomain: tenantSubdomain } })
+  if (!tenant) {
+    return { error: NextResponse.json({ error: 'Tenant not found' }, { status: 404 }) }
+  }
+
+  const user = await prisma.user.findUnique({ where: { id: token.sub } })
+  if (!user || user.tenantId !== tenant.id) {
+    return { error: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+
+  return { token, tenant, user }
+}
+
+export async function GET(request: NextRequest, { params }: { params: { tenant: string } }) {
+  const auth = await ensureUser(request, params.tenant)
+  if ('error' in auth) return auth.error
+  try {
+    const astForms = await prisma.aSTForm.findMany({
+      where: { tenantId: auth.tenant.id },
+      orderBy: { createdAt: 'desc' }
+    })
+    return NextResponse.json({ astForms })
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'An unexpected error occurred'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest, { params }: { params: { tenant: string } }) {
+  const auth = await ensureUser(request, params.tenant)
+  if ('error' in auth) return auth.error
+  try {
+    const body = await request.json()
+    const parsed = bodySchema.safeParse(body)
+    if (!parsed.success) {
+      return NextResponse.json({ success: false, error: 'Invalid request body' }, { status: 400 })
+    }
+    const { formData } = parsed.data
+
+    const astCount = await prisma.aSTForm.count({ where: { tenantId: auth.tenant.id } })
+    const astNumber = `AST-${new Date().getFullYear()}-${String(astCount + 1).padStart(3, '0')}`
+
+    const astForm = await prisma.aSTForm.create({
+      data: {
+        tenantId: auth.tenant.id,
+        userId: auth.user.id,
+        projectNumber: formData.projectNumber || '',
+        clientName: formData.client || '',
+        workLocation: formData.workLocation || '',
+        clientRep: formData.clientRep,
+        emergencyNumber: formData.emergencyNumber,
+        astMdlNumber: astNumber,
+        astClientNumber: formData.astClientNumber,
+        workDescription: formData.workDescription || '',
+        status: 'completed',
+        generalInfo: {
+          datetime: formData.datetime,
+          language: formData.language
+        },
+        teamDiscussion: formData.teamDiscussion,
+        isolation: formData.isolation,
+        hazards: formData.hazards,
+        controlMeasures: formData.controlMeasures,
+        workers: formData.workers,
+        photos: formData.photos
+      }
+    })
+
+    return NextResponse.json({ success: true, astForm, message: 'AST sauvegardé avec succès!' })
+  } catch (error: unknown) {
+    console.error('Error saving AST:', error)
+    const message = error instanceof Error ? error.message : 'An unexpected error occurred'
+    return NextResponse.json({ success: false, error: message }, { status: 500 })
+  }
+}

--- a/app/api/[tenant]/ast/save/route.ts
+++ b/app/api/[tenant]/ast/save/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getToken } from 'next-auth/jwt'
+import { prisma } from '@/lib/prisma'
+import env from '@/lib/env'
+
+async function ensureUser(request: NextRequest, tenantSubdomain: string) {
+  const token = await getToken({ req: request, secret: env.NEXTAUTH_SECRET })
+  if (!token?.sub) {
+    return { error: NextResponse.json({ error: 'Authentication required' }, { status: 401 }) }
+  }
+
+  const tenant = await prisma.tenant.findUnique({ where: { subdomain: tenantSubdomain } })
+  if (!tenant) {
+    return { error: NextResponse.json({ error: 'Tenant not found' }, { status: 404 }) }
+  }
+
+  const user = await prisma.user.findUnique({ where: { id: token.sub } })
+  if (!user || user.tenantId !== tenant.id) {
+    return { error: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+
+  return { tenant, user }
+}
+
+export async function POST(request: NextRequest, { params }: { params: { tenant: string } }) {
+  const auth = await ensureUser(request, params.tenant)
+  if ('error' in auth) return auth.error
+  try {
+    const data = await request.json()
+    if (!data?.id) {
+      return NextResponse.json({ error: 'AST id required' }, { status: 400 })
+    }
+
+    await prisma.aSTForm.upsert({
+      where: { id: data.id },
+      update: {
+        tenantId: auth.tenant.id,
+        userId: auth.user.id,
+        generalInfo: data.generalInfo ?? {},
+        teamDiscussion: data.teamDiscussion ?? {},
+        isolation: data.isolation ?? {},
+        hazards: data.hazards ?? {},
+        controlMeasures: data.controlMeasures ?? {},
+        workers: data.workers ?? {},
+        photos: data.photos ?? {},
+        projectNumber: data.projectNumber ?? '',
+        clientName: data.clientName ?? '',
+        workLocation: data.workLocation ?? '',
+        astMdlNumber: data.astMdlNumber ?? '',
+        astClientNumber: data.astClientNumber ?? '',
+        workDescription: data.workDescription ?? ''
+      },
+      create: {
+        id: data.id,
+        tenantId: auth.tenant.id,
+        userId: auth.user.id,
+        projectNumber: data.projectNumber ?? '',
+        clientName: data.clientName ?? '',
+        workLocation: data.workLocation ?? '',
+        clientRep: data.clientRep,
+        emergencyNumber: data.emergencyNumber,
+        astMdlNumber: data.astMdlNumber ?? '',
+        astClientNumber: data.astClientNumber,
+        workDescription: data.workDescription ?? '',
+        status: 'draft',
+        generalInfo: data.generalInfo ?? {},
+        teamDiscussion: data.teamDiscussion ?? {},
+        isolation: data.isolation ?? {},
+        hazards: data.hazards ?? {},
+        controlMeasures: data.controlMeasures ?? {},
+        workers: data.workers ?? {},
+        photos: data.photos ?? {}
+      }
+    })
+
+    return NextResponse.json({ success: true })
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'An unexpected error occurred'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- add tenant-scoped AST API endpoints
- document AST API usage
- cover unauthorized access with unit test

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689bf1b28d308323b708616288e73641