### PR TITLE
chore: add sanitize-html type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@types/qrcode": "^1.5.5",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "@types/sanitize-html": "^2.16.0",
         "eslint": "^8",
         "eslint-config-next": "14.0.4",
         "typescript": "^5",
@@ -1631,6 +1632,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/sanitize-html": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.0.tgz",
+      "integrity": "sha512-l6rX1MUXje5ztPT0cAFtUayXF06DqPhRyfVXareEN5gGCFaP/iwsxIyKODr9XDhfxPpN6vXUFNfo5kZMXCxBtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^8.0.0"
       }
     },
     "node_modules/@types/ws": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/qrcode": "^1.5.5",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/sanitize-html": "^2.16.0",
     "eslint": "^8",
     "eslint-config-next": "14.0.4",
     "typescript": "^5",


### PR DESCRIPTION
## Summary
- add `@types/sanitize-html` dev dependency for type support

## Testing
- `npm test`
- `npx tsc --noEmit` *(fails: Type 'unknown[] | undefined' is not assignable to type 'NullableJsonNullValueInput | InputJsonValue | undefined')*

------
https://chatgpt.com/codex/tasks/task_e_689bf5338d348323af62129067dd4107