### PR TITLE
feat(ast): add isolation circuit typing

### DIFF
--- a/app/[tenant]/ast/[id]/page.tsx
+++ b/app/[tenant]/ast/[id]/page.tsx
@@ -2,6 +2,7 @@ import { prisma } from '@/lib/prisma'
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { ArrowLeft, Download, Share } from 'lucide-react'
+import { IsolationCircuit } from '@/types/astPayload'
 
 interface ASTDetailPageProps {
   params: { tenant: string; id: string }
@@ -126,7 +127,7 @@ export default async function ASTDetailPage({ params }: ASTDetailPageProps) {
               )}
               {isolation.circuits && isolation.circuits.length > 0 && (
                 <div className="space-y-3">
-                  {isolation.circuits.map((circuit: any, index: number) => (
+                  {isolation.circuits.map((circuit: IsolationCircuit, index: number) => (
                     <div key={index} className="bg-slate-700/50 p-4 rounded-lg">
                       <h4 className="text-white font-semibold mb-2">{circuit.name}</h4>
                       <div className="grid grid-cols-3 gap-4 text-sm">

--- a/app/types/astPayload.ts
+++ b/app/types/astPayload.ts
@@ -1,0 +1,6 @@
+export interface IsolationCircuit {
+  name: string;
+  padlock: boolean;
+  voltage: boolean;
+  grounding: boolean;
+}


### PR DESCRIPTION
## Summary
- type isolation circuits with IsolationCircuit interface
- import IsolationCircuit in AST detail page

## Testing
- `npm run build` *(fails: Route "app/api/ast/route.ts" does not match the required types)*
- `npx tsc --noEmit` *(fails: Type 'unknown[] | undefined' is not assignable to type 'NullableJsonNullValueInput | InputJsonValue | undefined')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bfb8a8cd083239843601c79590f08