### PR TITLE
Ensure tenant middleware falls back to default

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -8,4 +8,5 @@ NEXTAUTH_URL=http://localhost:3000
 
 NEXT_PUBLIC_APP_NAME="AST MDL"
 NEXT_PUBLIC_DEFAULT_TENANT="demo"
+VALID_TENANTS=demo
 WEATHER_API_KEY=your-openweather-api-key

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,11 +3,9 @@ import type { NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
   const url = request.nextUrl.clone()
-  const hostname = request.headers.get('host') || ''
-  
-  // Extraire le sous-domaine
-  const subdomain = hostname.split('.')[0]
-  
+  const requestHost = request.headers.get('host') || ''
+  const hostname = requestHost.split(':')[0]
+
   // Récupérer dynamiquement la liste des sous-domaines valides via une variable d'environnement
   const validTenantsEnv = process.env.VALID_TENANTS || ''
   const validTenants = validTenantsEnv
@@ -15,14 +13,19 @@ export function middleware(request: NextRequest) {
     .map((tenant) => tenant.trim())
     .filter(Boolean)
 
-  // Gérer les tenants inconnus
-  if (!validTenants.includes(subdomain) && !hostname.includes('localhost')) {
-    return NextResponse.json({ error: 'Unknown tenant' }, { status: 404 })
-  }
+  const defaultTenant =
+    process.env.NEXT_PUBLIC_DEFAULT_TENANT || validTenants[0] || 'demo'
 
-  const currentTenant = hostname.includes('localhost')
-    ? validTenants[0] || 'demo'
-    : subdomain
+  // Extraire le sous-domaine sans le port
+  const subdomain = hostname.split('.')[0]
+
+  // Déterminer le tenant courant ou retomber sur le tenant par défaut
+  const currentTenant =
+    hostname.includes('localhost') ||
+    !subdomain ||
+    !validTenants.includes(subdomain)
+      ? defaultTenant
+      : subdomain
 
   // Si l'URL ne commence pas déjà par le tenant
   if (!url.pathname.startsWith(`/${currentTenant}`)) {


### PR DESCRIPTION
## Summary
- configure valid tenants via `VALID_TENANTS` env var
- make middleware default to `NEXT_PUBLIC_DEFAULT_TENANT` when tenant is local or missing

## Testing
- `npm test`
- `npm run build` *(fails: sanitizeFormData is not a valid Route export field)*

------
https://chatgpt.com/codex/tasks/task_e_689bfb8b723483238235678c5a191812