### PR TITLE
refactor ast route helpers

### DIFF
--- a/app/api/ast/route.test.ts
+++ b/app/api/ast/route.test.ts
@@ -9,7 +9,7 @@ vi.mock('next-auth/jwt', () => ({ getToken: vi.fn() }))
 vi.mock('@/lib/prisma', () => ({ prisma: {} }))
 vi.mock('@/lib/env', () => ({ default: {} }))
 
-import { sanitizeFormData } from './route'
+import { sanitizeFormData } from './utils'
 
 describe('sanitizeFormData', () => {
   it('sanitizes strings nested inside objects and arrays', () => {

--- a/app/api/ast/utils.ts
+++ b/app/api/ast/utils.ts
@@ -1,0 +1,26 @@
+import sanitizeHtml from 'sanitize-html'
+
+export function sanitizeFormData<T>(data: T): T {
+  const sanitizeValue = (value: unknown): unknown => {
+    if (typeof value === 'string') {
+      return sanitizeHtml(value)
+    }
+    if (Array.isArray(value)) {
+      return value.map(sanitizeValue)
+    }
+    if (value && typeof value === 'object') {
+      const obj: Record<string, unknown> = {}
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        obj[k] = sanitizeValue(v)
+      }
+      return obj
+    }
+    return value
+  }
+
+  const sanitized: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
+    sanitized[key] = sanitizeValue(value)
+  }
+  return sanitized as T
+}


### PR DESCRIPTION
## Summary
- move `sanitizeFormData` into `app/api/ast/utils.ts` and import in route
- keep only `POST` and `GET` exports in `app/api/ast/route.ts`
- update unit tests for new helper location

## Testing
- `npm test`
- `npm run build`
- `npm run deploy` *(fails: Missing script "deploy")*


------
https://chatgpt.com/codex/tasks/task_e_689bffacfbac83238cbff32e73c10b98