### PR TITLE
refactor: use scoped env imports

### DIFF
--- a/app/api/[tenant]/ast/[id]/route.ts
+++ b/app/api/[tenant]/ast/[id]/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { prisma } from '@/lib/prisma'
-import env from '@/lib/env'
+import { SERVER_ENV } from '@/lib/env'
 
 async function ensureUser(request: NextRequest, tenantSubdomain: string) {
-  const token = await getToken({ req: request, secret: env.NEXTAUTH_SECRET })
+  const token = await getToken({ req: request, secret: SERVER_ENV.NEXTAUTH_SECRET })
   if (!token?.sub) {
     return { error: NextResponse.json({ error: 'Authentication required' }, { status: 401 }) }
   }

--- a/app/api/[tenant]/ast/route.test.ts
+++ b/app/api/[tenant]/ast/route.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/lib/prisma', () => ({
 }))
 
 vi.mock('@/lib/env', () => ({
-  default: { NEXTAUTH_SECRET: 'test' }
+  SERVER_ENV: { NEXTAUTH_SECRET: 'test' }
 }))
 
 describe('GET /api/[tenant]/ast', () => {

--- a/app/api/[tenant]/ast/route.ts
+++ b/app/api/[tenant]/ast/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { prisma } from '@/lib/prisma'
-import env from '@/lib/env'
+import { SERVER_ENV } from '@/lib/env'
 import { z } from 'zod'
 
 const bodySchema = z.object({
@@ -9,7 +9,7 @@ const bodySchema = z.object({
 })
 
 async function ensureUser(request: NextRequest, tenantSubdomain: string) {
-  const token = await getToken({ req: request, secret: env.NEXTAUTH_SECRET })
+  const token = await getToken({ req: request, secret: SERVER_ENV.NEXTAUTH_SECRET })
   if (!token?.sub) {
     return { error: NextResponse.json({ error: 'Authentication required' }, { status: 401 }) }
   }

--- a/app/api/[tenant]/ast/save/route.ts
+++ b/app/api/[tenant]/ast/save/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { prisma } from '@/lib/prisma'
-import env from '@/lib/env'
+import { SERVER_ENV } from '@/lib/env'
 
 async function ensureUser(request: NextRequest, tenantSubdomain: string) {
-  const token = await getToken({ req: request, secret: env.NEXTAUTH_SECRET })
+  const token = await getToken({ req: request, secret: SERVER_ENV.NEXTAUTH_SECRET })
   if (!token?.sub) {
     return { error: NextResponse.json({ error: 'Authentication required' }, { status: 401 }) }
   }

--- a/app/api/ast/route.test.ts
+++ b/app/api/ast/route.test.ts
@@ -7,7 +7,7 @@ vi.mock('next/server', () => ({
 
 vi.mock('next-auth/jwt', () => ({ getToken: vi.fn() }))
 vi.mock('@/lib/prisma', () => ({ prisma: {} }))
-vi.mock('@/lib/env', () => ({ default: {} }))
+vi.mock('@/lib/env', () => ({ SERVER_ENV: {} }))
 
 import { sanitizeFormData } from './utils'
 

--- a/app/api/ast/route.ts
+++ b/app/api/ast/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { prisma } from '@/lib/prisma'
 import { z } from 'zod'
-import env from '@/lib/env'
+import { SERVER_ENV } from '@/lib/env'
 import { sanitizeFormData } from './utils'
 
 const formDataSchema = z.object({
@@ -44,7 +44,7 @@ const requestSchema = z.object({
 
 export async function POST(request: NextRequest) {
   try {
-    const token = await getToken({ req: request, secret: env.NEXTAUTH_SECRET })
+    const token = await getToken({ req: request, secret: SERVER_ENV.NEXTAUTH_SECRET })
     const userId = token?.sub
     if (!userId) {
       return NextResponse.json(
@@ -113,7 +113,7 @@ export async function POST(request: NextRequest) {
 
 export async function GET(request: NextRequest) {
   try {
-    const token = await getToken({ req: request, secret: env.NEXTAUTH_SECRET })
+    const token = await getToken({ req: request, secret: SERVER_ENV.NEXTAUTH_SECRET })
     if (!token?.sub) {
       return NextResponse.json(
         { error: 'Authentication required' },

--- a/app/utils/documentGeneration.ts
+++ b/app/utils/documentGeneration.ts
@@ -3,7 +3,7 @@
 import { AST, ASTStatus } from '../types/ast';
 import { ComplianceReport } from './compliance';
 import { RiskLevel } from '../types/index';
-import env from '@/lib/env';
+import { SERVER_ENV } from '@/lib/env';
 
 // =================== INTERFACES NOTIFICATIONS ===================
 export interface NotificationTemplate {
@@ -553,7 +553,7 @@ export async function sendComplianceNotification(
   const variables = {
     complianceScore: complianceReport.overallScore,
     criticalActionsCount: complianceReport.criticalActions.length,
-    complianceReportUrl: `${env.BASE_URL}/compliance/${complianceReport.tenantId}`,
+    complianceReportUrl: `${SERVER_ENV.BASE_URL}/compliance/${complianceReport.tenantId}`,
     generatedAt: complianceReport.generatedAt,
     nextReviewDate: complianceReport.nextReviewDate
   };
@@ -802,7 +802,7 @@ function prepareASTVariables(ast: AST, additionalData?: Record<string, any>): Re
     plannedStartDate: astAny.plannedStartDate || new Date().toISOString(),
     plannedEndDate: astAny.plannedEndDate || new Date().toISOString(),
     status: ast.status || 'DRAFT',
-    astUrl: `${env.BASE_URL}/ast/${ast.id}`,
+    astUrl: `${SERVER_ENV.BASE_URL}/ast/${ast.id}`,
     ...additionalData
   };
 }

--- a/components/ASTContext.tsx
+++ b/components/ASTContext.tsx
@@ -2,7 +2,7 @@
 
 import React, { createContext, useContext, useReducer, useCallback, useRef, useState, useEffect } from 'react';
 import { ASTFormData } from '@/types/astForm';
-import env from '@/lib/env';
+import { PUBLIC_ENV } from '@/lib/env';
 
 // =================== INTERFACES MULTI-TENANT ===================
 export interface TenantConfig {
@@ -349,7 +349,7 @@ async function saveToTenantDatabase(
 ) {
   try {
     // 🚀 Mode development - simulation API
-    if (env.NODE_ENV === 'development') {
+    if (PUBLIC_ENV.NODE_ENV === 'development') {
       console.log('💾 DEV - Sauvegarde simulée:', {
         tenant: dbConfig.schema,
         section,

--- a/components/steps/Step4Permits/ConfinedSpace/SafetyManager.tsx
+++ b/components/steps/Step4Permits/ConfinedSpace/SafetyManager.tsx
@@ -4,12 +4,12 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { createClient } from '@supabase/supabase-js';
-import env from '@/lib/env';
+import { PUBLIC_ENV } from '@/lib/env';
 
 // =================== CONFIGURATION SUPABASE ROBUSTE ===================
 const FALLBACK_URL = 'http://localhost:54321';
-const supabaseUrlEnv = env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseKey = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const supabaseUrlEnv = PUBLIC_ENV.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = PUBLIC_ENV.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
 let supabase: any = null;
 let supabaseEnabled = false;

--- a/hooks/useGoogleMaps.ts
+++ b/hooks/useGoogleMaps.ts
@@ -1,7 +1,7 @@
 // hooks/useGoogleMaps.ts
 /// <reference types="google.maps" />
 import { useState, useEffect } from 'react';
-import env from '@/lib/env';
+import { PUBLIC_ENV } from '@/lib/env';
 
 type GoogleWindow = typeof window & { google?: typeof google };
 
@@ -30,7 +30,7 @@ export const useGoogleMaps = (config?: GoogleMapsConfig) => {
   const [error, setError] = useState<string | null>(null);
 
   const defaultConfig: GoogleMapsConfig = {
-    apiKey: env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || 'demo-key',
+    apiKey: PUBLIC_ENV.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || 'demo-key',
     libraries: ['places', 'geometry'],
     region: 'CA',
     language: 'fr',

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -8,6 +8,7 @@ const clientSchema = z.object({
   NEXT_PUBLIC_APP_NAME: z.string(),
   NEXT_PUBLIC_DEFAULT_TENANT: z.string(),
   NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: z.string().optional(),
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
 });
 
 const serverSchema = z.object({
@@ -17,7 +18,6 @@ const serverSchema = z.object({
   NEXTAUTH_URL: z.string().url(),
   WEATHER_API_KEY: z.string(),
   BASE_URL: z.string().url().default('http://localhost:3000'),
-  // Default to development unless explicitly set to production
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
 });
 
@@ -40,39 +40,24 @@ const clientEnv: ClientEnv = skipValidation
   ? (process.env as unknown as ClientEnv)
   : parseClientEnv();
 
-let serverEnv: ServerEnv | null = null;
-const loadServerEnv = (): ServerEnv => {
-  if (serverEnv) return serverEnv;
-  if (skipValidation) {
-    serverEnv = {
-      BASE_URL: 'http://localhost:3000',
-      ...process.env,
-    } as unknown as ServerEnv;
-    return serverEnv;
-  }
-  const parsed = serverSchema.safeParse(process.env);
-  if (!parsed.success) {
-    parsed.error.issues
-      .filter((issue) => issue.message === 'Required')
-      .forEach((issue) => console.error(`❌ Missing environment variable: ${issue.path.join('.')}`));
-    console.error('❌ Invalid environment variables', parsed.error.flatten().fieldErrors);
-    throw new Error('Missing or invalid environment variables');
-  }
-  serverEnv = parsed.data;
-  return serverEnv;
-};
+const serverEnv: ServerEnv = skipValidation
+  ? ({ BASE_URL: 'http://localhost:3000', ...process.env } as unknown as ServerEnv)
+  : (() => {
+      const parsed = serverSchema.safeParse(process.env);
+      if (!parsed.success) {
+        parsed.error.issues
+          .filter((issue) => issue.message === 'Required')
+          .forEach((issue) => console.error(`❌ Missing environment variable: ${issue.path.join('.')}`));
+        console.error('❌ Invalid environment variables', parsed.error.flatten().fieldErrors);
+        throw new Error('Missing or invalid environment variables');
+      }
+      return parsed.data;
+    })();
 
-export const env: ClientEnv & ServerEnv = clientEnv as ClientEnv & ServerEnv;
-for (const key of Object.keys(serverSchema.shape)) {
-  Object.defineProperty(env, key, {
-    enumerable: true,
-    get() {
-      return loadServerEnv()[key as keyof ServerEnv];
-    },
-  });
-}
+export const PUBLIC_ENV = clientEnv;
+export const SERVER_ENV = serverEnv;
 
-export const getServerEnv = loadServerEnv;
 export type Env = ClientEnv & ServerEnv;
+export const env: Env = { ...PUBLIC_ENV, ...SERVER_ENV };
 export default env;
 

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from '@prisma/client'
-import env from '@/lib/env'
+import { SERVER_ENV } from '@/lib/env'
 
 // Cache Prisma Client instance on `globalThis` to avoid re-instantiation
 // during development hot reloads. Prisma connects lazily on first use.
@@ -9,6 +9,6 @@ const globalForPrisma = globalThis as unknown as {
 
 export const prisma = globalForPrisma.prisma ?? new PrismaClient()
 
-if (env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+if (SERVER_ENV.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
 
 export default prisma

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,9 +1,9 @@
 import { createClient } from '@supabase/supabase-js'
-import env from '@/lib/env'
+import { PUBLIC_ENV } from '@/lib/env'
 
 const FALLBACK_URL = 'http://localhost:54321'
-const supabaseUrlEnv = env.NEXT_PUBLIC_SUPABASE_URL
-const supabaseAnonKey = env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+const supabaseUrlEnv = PUBLIC_ENV.NEXT_PUBLIC_SUPABASE_URL
+const supabaseAnonKey = PUBLIC_ENV.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
 if (!supabaseAnonKey) {
   console.error('Missing NEXT_PUBLIC_SUPABASE_ANON_KEY. Set it in your .env.local file.')

--- a/lib/weatherApi.ts
+++ b/lib/weatherApi.ts
@@ -1,5 +1,5 @@
 import type { WeatherData } from '../hooks/useWeatherData';
-import env from '@/lib/env';
+import { SERVER_ENV } from '@/lib/env';
 
 const API_BASE = 'https://api.openweathermap.org/data/3.0/onecall';
 const DEFAULT_TIMEOUT = 5000;
@@ -10,7 +10,7 @@ const degToCompass = (deg: number): string => {
 };
 
 export async function getWeatherData(lat: number, lng: number): Promise<WeatherData> {
-  const apiKey = env.WEATHER_API_KEY;
+  const apiKey = SERVER_ENV.WEATHER_API_KEY;
   if (!apiKey) {
     throw new Error('WEATHER_API_KEY is not defined');
   }


### PR DESCRIPTION
## Summary
- export separate PUBLIC_ENV and SERVER_ENV helpers
- replace default env imports with PUBLIC_ENV or SERVER_ENV in client/server modules
- update tests to mock SERVER_ENV

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c054f38dc832398ea72b533c32d66