### PR TITLE
chore: ensure dynamic node runtime for env routes

### DIFF
--- a/app/api/[tenant]/ast/[id]/route.ts
+++ b/app/api/[tenant]/ast/[id]/route.ts
@@ -3,6 +3,9 @@ import { getToken } from 'next-auth/jwt'
 import { prisma } from '@/lib/prisma'
 import env from '@/lib/env'
 
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
 async function ensureUser(request: NextRequest, tenantSubdomain: string) {
   const token = await getToken({ req: request, secret: env.NEXTAUTH_SECRET })
   if (!token?.sub) {

--- a/app/api/[tenant]/ast/route.ts
+++ b/app/api/[tenant]/ast/route.ts
@@ -4,6 +4,9 @@ import { prisma } from '@/lib/prisma'
 import env from '@/lib/env'
 import { z } from 'zod'
 
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
 const bodySchema = z.object({
   formData: z.any()
 })

--- a/app/api/[tenant]/ast/save/route.ts
+++ b/app/api/[tenant]/ast/save/route.ts
@@ -3,6 +3,9 @@ import { getToken } from 'next-auth/jwt'
 import { prisma } from '@/lib/prisma'
 import env from '@/lib/env'
 
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
 async function ensureUser(request: NextRequest, tenantSubdomain: string) {
   const token = await getToken({ req: request, secret: env.NEXTAUTH_SECRET })
   if (!token?.sub) {

--- a/app/api/ast/route.ts
+++ b/app/api/ast/route.ts
@@ -5,6 +5,9 @@ import { z } from 'zod'
 import env from '@/lib/env'
 import { sanitizeFormData } from './utils'
 
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
 const formDataSchema = z.object({
   projectNumber: z.string().trim().optional(),
   client: z.string().trim().optional(),


### PR DESCRIPTION
## Summary
- force dynamic rendering for AST API routes that read server env
- specify Node.js runtime for those routes to avoid build-time execution

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689c0550cfc88323b0615c69d4cdafe8