### PR TITLE
docs: add missing env placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,4 +9,7 @@ NEXTAUTH_URL="https://your-deployment-url"
 
 NEXT_PUBLIC_APP_NAME="AST MDL"
 NEXT_PUBLIC_DEFAULT_TENANT="demo"
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY="your-google-maps-api-key"
 WEATHER_API_KEY="your-openweather-api-key"
+BASE_URL="http://localhost:3000"
+NODE_ENV="development"


### PR DESCRIPTION
## Summary
- include placeholders for Google Maps API, base URL, and node environment in `.env.example`
- ensure example environment file covers all client and server env keys

## Testing
- `SKIP_ENV_VALIDATION=1 npm test`
- `SKIP_ENV_VALIDATION=1 npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689c055146988323b67076d7c9747696