### PR TITLE
test: mock env for AST routes

### DIFF
--- a/app/api/ast/route.test.ts
+++ b/app/api/ast/route.test.ts
@@ -7,7 +7,10 @@ vi.mock('next/server', () => ({
 
 vi.mock('next-auth/jwt', () => ({ getToken: vi.fn() }))
 vi.mock('@/lib/prisma', () => ({ prisma: {} }))
-vi.mock('@/lib/env', () => ({ PUBLIC_ENV: {}, SERVER_ENV: {} }))
+vi.mock('@/lib/env', () => ({
+  SERVER_ENV: { NEXTAUTH_SECRET: 'test' },
+  PUBLIC_ENV: {}
+}))
 
 import { sanitizeFormData } from './utils'
 


### PR DESCRIPTION
## Summary
- provide NEXTAUTH_SECRET when mocking env in AST route tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c8be4f4988323bab9ef5a11b1b5fe