### PR TITLE
chore(env): export named environment constants

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -59,11 +59,34 @@ const parseServerEnv = (): ServerEnv => {
   return parsed.data;
 };
 
+/**
+ * @deprecated Use named exports like {@link NEXT_PUBLIC_SUPABASE_URL} instead.
+ */
 export const PUBLIC_ENV: ClientEnv = skipValidation
   ? (clientVariables as ClientEnv)
   : parseClientEnv(clientVariables);
 
+export const NEXT_PUBLIC_SUPABASE_URL = PUBLIC_ENV.NEXT_PUBLIC_SUPABASE_URL;
+export const NEXT_PUBLIC_SUPABASE_ANON_KEY =
+  PUBLIC_ENV.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+export const NEXT_PUBLIC_APP_NAME = PUBLIC_ENV.NEXT_PUBLIC_APP_NAME;
+export const NEXT_PUBLIC_DEFAULT_TENANT =
+  PUBLIC_ENV.NEXT_PUBLIC_DEFAULT_TENANT;
+export const NEXT_PUBLIC_GOOGLE_MAPS_API_KEY =
+  PUBLIC_ENV.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+
+/**
+ * @deprecated Use named exports like {@link NODE_ENV} instead.
+ */
 export const SERVER_ENV: ServerEnv = skipValidation
   ? ({ BASE_URL: 'http://localhost:3000', ...process.env } as unknown as ServerEnv)
   : parseServerEnv();
+
+export const DATABASE_URL = SERVER_ENV.DATABASE_URL;
+export const SUPABASE_SERVICE_ROLE_KEY = SERVER_ENV.SUPABASE_SERVICE_ROLE_KEY;
+export const NEXTAUTH_SECRET = SERVER_ENV.NEXTAUTH_SECRET;
+export const NEXTAUTH_URL = SERVER_ENV.NEXTAUTH_URL;
+export const WEATHER_API_KEY = SERVER_ENV.WEATHER_API_KEY;
+export const BASE_URL = SERVER_ENV.BASE_URL;
+export const NODE_ENV = SERVER_ENV.NODE_ENV;
 


### PR DESCRIPTION
## Summary
- expose validated environment variables as named constants for client and server
- mark PUBLIC_ENV and SERVER_ENV as deprecated for backwards compatibility

## Testing
- `SKIP_ENV_VALIDATION=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c8be6fc7883239e5afb27157b9730