### PR TITLE
refactor: import specific env constants

### DIFF
--- a/app/api/[tenant]/ast/[id]/route.ts
+++ b/app/api/[tenant]/ast/[id]/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { prisma } from '@/lib/prisma'
-import { SERVER_ENV } from '@/lib/env'
+import { NEXTAUTH_SECRET } from '@/lib/env'
 
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
 
 async function ensureUser(request: NextRequest, tenantSubdomain: string) {
-  const token = await getToken({ req: request, secret: SERVER_ENV.NEXTAUTH_SECRET })
+  const token = await getToken({ req: request, secret: NEXTAUTH_SECRET })
   if (!token?.sub) {
     return { error: NextResponse.json({ error: 'Authentication required' }, { status: 401 }) }
   }

--- a/app/api/[tenant]/ast/route.test.ts
+++ b/app/api/[tenant]/ast/route.test.ts
@@ -13,8 +13,11 @@ vi.mock('@/lib/prisma', () => ({
 }))
 
 vi.mock('@/lib/env', () => ({
-  SERVER_ENV: { NEXTAUTH_SECRET: 'test' },
-  PUBLIC_ENV: {}
+  NEXTAUTH_SECRET: 'test',
+  PUBLIC_ENV: {},
+  NODE_ENV: 'test',
+  WEATHER_API_KEY: '',
+  BASE_URL: ''
 }))
 
 describe('GET /api/[tenant]/ast', () => {

--- a/app/api/[tenant]/ast/route.ts
+++ b/app/api/[tenant]/ast/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { prisma } from '@/lib/prisma'
-import { SERVER_ENV } from '@/lib/env'
+import { NEXTAUTH_SECRET } from '@/lib/env'
 import { z } from 'zod'
 
 export const dynamic = 'force-dynamic'
@@ -12,7 +12,7 @@ const bodySchema = z.object({
 })
 
 async function ensureUser(request: NextRequest, tenantSubdomain: string) {
-  const token = await getToken({ req: request, secret: SERVER_ENV.NEXTAUTH_SECRET })
+  const token = await getToken({ req: request, secret: NEXTAUTH_SECRET })
   if (!token?.sub) {
     return { error: NextResponse.json({ error: 'Authentication required' }, { status: 401 }) }
   }

--- a/app/api/[tenant]/ast/save/route.ts
+++ b/app/api/[tenant]/ast/save/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { prisma } from '@/lib/prisma'
-import { SERVER_ENV } from '@/lib/env'
+import { NEXTAUTH_SECRET } from '@/lib/env'
 
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
 
 async function ensureUser(request: NextRequest, tenantSubdomain: string) {
-  const token = await getToken({ req: request, secret: SERVER_ENV.NEXTAUTH_SECRET })
+  const token = await getToken({ req: request, secret: NEXTAUTH_SECRET })
   if (!token?.sub) {
     return { error: NextResponse.json({ error: 'Authentication required' }, { status: 401 }) }
   }

--- a/app/api/ast/route.test.ts
+++ b/app/api/ast/route.test.ts
@@ -7,7 +7,13 @@ vi.mock('next/server', () => ({
 
 vi.mock('next-auth/jwt', () => ({ getToken: vi.fn() }))
 vi.mock('@/lib/prisma', () => ({ prisma: {} }))
-vi.mock('@/lib/env', () => ({ PUBLIC_ENV: {}, SERVER_ENV: {} }))
+vi.mock('@/lib/env', () => ({
+  PUBLIC_ENV: {},
+  NODE_ENV: 'test',
+  WEATHER_API_KEY: '',
+  NEXTAUTH_SECRET: '',
+  BASE_URL: ''
+}))
 
 import { sanitizeFormData } from './utils'
 

--- a/app/api/ast/route.ts
+++ b/app/api/ast/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { prisma } from '@/lib/prisma'
 import { z } from 'zod'
-import { SERVER_ENV } from '@/lib/env'
+import { NEXTAUTH_SECRET } from '@/lib/env'
 import { sanitizeFormData } from './utils'
 
 export const dynamic = 'force-dynamic'
@@ -47,7 +47,7 @@ const requestSchema = z.object({
 
 export async function POST(request: NextRequest) {
   try {
-    const token = await getToken({ req: request, secret: SERVER_ENV.NEXTAUTH_SECRET })
+    const token = await getToken({ req: request, secret: NEXTAUTH_SECRET })
     const userId = token?.sub
     if (!userId) {
       return NextResponse.json(
@@ -116,7 +116,7 @@ export async function POST(request: NextRequest) {
 
 export async function GET(request: NextRequest) {
   try {
-    const token = await getToken({ req: request, secret: SERVER_ENV.NEXTAUTH_SECRET })
+    const token = await getToken({ req: request, secret: NEXTAUTH_SECRET })
     if (!token?.sub) {
       return NextResponse.json(
         { error: 'Authentication required' },

--- a/app/utils/documentGeneration.ts
+++ b/app/utils/documentGeneration.ts
@@ -3,7 +3,7 @@
 import { AST, ASTStatus } from '../types/ast';
 import { ComplianceReport } from './compliance';
 import { RiskLevel } from '../types/index';
-import { SERVER_ENV } from '@/lib/env';
+import { BASE_URL } from '@/lib/env';
 
 // =================== INTERFACES NOTIFICATIONS ===================
 export interface NotificationTemplate {
@@ -553,7 +553,7 @@ export async function sendComplianceNotification(
   const variables = {
     complianceScore: complianceReport.overallScore,
     criticalActionsCount: complianceReport.criticalActions.length,
-    complianceReportUrl: `${SERVER_ENV.BASE_URL}/compliance/${complianceReport.tenantId}`,
+    complianceReportUrl: `${BASE_URL}/compliance/${complianceReport.tenantId}`,
     generatedAt: complianceReport.generatedAt,
     nextReviewDate: complianceReport.nextReviewDate
   };
@@ -802,7 +802,7 @@ function prepareASTVariables(ast: AST, additionalData?: Record<string, any>): Re
     plannedStartDate: astAny.plannedStartDate || new Date().toISOString(),
     plannedEndDate: astAny.plannedEndDate || new Date().toISOString(),
     status: ast.status || 'DRAFT',
-    astUrl: `${SERVER_ENV.BASE_URL}/ast/${ast.id}`,
+    astUrl: `${BASE_URL}/ast/${ast.id}`,
     ...additionalData
   };
 }

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -67,3 +67,10 @@ export const SERVER_ENV: ServerEnv = skipValidation
   ? ({ BASE_URL: 'http://localhost:3000', ...process.env } as unknown as ServerEnv)
   : parseServerEnv();
 
+export const {
+  NODE_ENV,
+  WEATHER_API_KEY,
+  NEXTAUTH_SECRET,
+  BASE_URL,
+} = SERVER_ENV;
+

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from '@prisma/client'
-import { SERVER_ENV } from '@/lib/env'
+import { NODE_ENV } from '@/lib/env'
 
 // Cache Prisma Client instance on `globalThis` to avoid re-instantiation
 // during development hot reloads. Prisma connects lazily on first use.
@@ -9,6 +9,6 @@ const globalForPrisma = globalThis as unknown as {
 
 export const prisma = globalForPrisma.prisma ?? new PrismaClient()
 
-if (SERVER_ENV.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+if (NODE_ENV !== 'production') globalForPrisma.prisma = prisma
 
 export default prisma

--- a/lib/weatherApi.ts
+++ b/lib/weatherApi.ts
@@ -1,5 +1,5 @@
 import type { WeatherData } from '../hooks/useWeatherData';
-import { SERVER_ENV } from '@/lib/env';
+import { WEATHER_API_KEY } from '@/lib/env';
 
 const API_BASE = 'https://api.openweathermap.org/data/3.0/onecall';
 const DEFAULT_TIMEOUT = 5000;
@@ -10,7 +10,7 @@ const degToCompass = (deg: number): string => {
 };
 
 export async function getWeatherData(lat: number, lng: number): Promise<WeatherData> {
-  const apiKey = SERVER_ENV.WEATHER_API_KEY;
+  const apiKey = WEATHER_API_KEY;
   if (!apiKey) {
     throw new Error('WEATHER_API_KEY is not defined');
   }


### PR DESCRIPTION
## Summary
- export individual server env constants
- import NODE_ENV, WEATHER_API_KEY, BASE_URL and NEXTAUTH_SECRET directly
- update tests to mock new env exports

## Testing
- `npm test`
- `npm run lint` *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689c8be639c483239f8bc0072caa14af