### PR TITLE
refactor: expose env constants

### DIFF
--- a/app/api/[tenant]/ast/route.test.ts
+++ b/app/api/[tenant]/ast/route.test.ts
@@ -14,7 +14,10 @@ vi.mock('@/lib/prisma', () => ({
 
 vi.mock('@/lib/env', () => ({
   SERVER_ENV: { NEXTAUTH_SECRET: 'test' },
-  PUBLIC_ENV: {}
+  PUBLIC_ENV: {},
+  NEXT_PUBLIC_SUPABASE_URL: '',
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: '',
+  NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: '',
 }))
 
 describe('GET /api/[tenant]/ast', () => {

--- a/app/api/ast/route.test.ts
+++ b/app/api/ast/route.test.ts
@@ -7,7 +7,13 @@ vi.mock('next/server', () => ({
 
 vi.mock('next-auth/jwt', () => ({ getToken: vi.fn() }))
 vi.mock('@/lib/prisma', () => ({ prisma: {} }))
-vi.mock('@/lib/env', () => ({ PUBLIC_ENV: {}, SERVER_ENV: {} }))
+vi.mock('@/lib/env', () => ({
+  PUBLIC_ENV: {},
+  SERVER_ENV: {},
+  NEXT_PUBLIC_SUPABASE_URL: '',
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: '',
+  NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: '',
+}))
 
 import { sanitizeFormData } from './utils'
 

--- a/components/steps/Step4Permits/ConfinedSpace/SafetyManager.tsx
+++ b/components/steps/Step4Permits/ConfinedSpace/SafetyManager.tsx
@@ -4,12 +4,12 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { createClient } from '@supabase/supabase-js';
-import { PUBLIC_ENV } from '@/lib/env';
+import { NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY } from '@/lib/env';
 
 // =================== CONFIGURATION SUPABASE ROBUSTE ===================
 const FALLBACK_URL = 'http://localhost:54321';
-const supabaseUrlEnv = PUBLIC_ENV.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseKey = PUBLIC_ENV.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const supabaseUrlEnv = NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
 let supabase: any = null;
 let supabaseEnabled = false;

--- a/hooks/useGoogleMaps.ts
+++ b/hooks/useGoogleMaps.ts
@@ -1,7 +1,7 @@
 // hooks/useGoogleMaps.ts
 /// <reference types="google.maps" />
 import { useState, useEffect } from 'react';
-import { PUBLIC_ENV } from '@/lib/env';
+import { NEXT_PUBLIC_GOOGLE_MAPS_API_KEY } from '@/lib/env';
 
 type GoogleWindow = typeof window & { google?: typeof google };
 
@@ -30,7 +30,7 @@ export const useGoogleMaps = (config?: GoogleMapsConfig) => {
   const [error, setError] = useState<string | null>(null);
 
   const defaultConfig: GoogleMapsConfig = {
-    apiKey: PUBLIC_ENV.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || 'demo-key',
+    apiKey: NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || 'demo-key',
     libraries: ['places', 'geometry'],
     region: 'CA',
     language: 'fr',

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -63,6 +63,10 @@ export const PUBLIC_ENV: ClientEnv = skipValidation
   ? (clientVariables as ClientEnv)
   : parseClientEnv(clientVariables);
 
+export const NEXT_PUBLIC_SUPABASE_URL = PUBLIC_ENV.NEXT_PUBLIC_SUPABASE_URL;
+export const NEXT_PUBLIC_SUPABASE_ANON_KEY = PUBLIC_ENV.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+export const NEXT_PUBLIC_GOOGLE_MAPS_API_KEY = PUBLIC_ENV.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+
 export const SERVER_ENV: ServerEnv = skipValidation
   ? ({ BASE_URL: 'http://localhost:3000', ...process.env } as unknown as ServerEnv)
   : parseServerEnv();

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,9 +1,9 @@
 import { createClient } from '@supabase/supabase-js'
-import { PUBLIC_ENV } from '@/lib/env'
+import { NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY } from '@/lib/env'
 
 const FALLBACK_URL = 'http://localhost:54321'
-const supabaseUrlEnv = PUBLIC_ENV.NEXT_PUBLIC_SUPABASE_URL
-const supabaseAnonKey = PUBLIC_ENV.NEXT_PUBLIC_SUPABASE_ANON_KEY
+const supabaseUrlEnv = NEXT_PUBLIC_SUPABASE_URL
+const supabaseAnonKey = NEXT_PUBLIC_SUPABASE_ANON_KEY
 
 if (!supabaseAnonKey) {
   console.error('Missing NEXT_PUBLIC_SUPABASE_ANON_KEY. Set it in your .env.local file.')


### PR DESCRIPTION
## Summary
- expose client env variables as named exports
- use named env constants in supabase, Google Maps hook, and SafetyManager
- update tests to mock new env constants

## Testing
- `npm test`
- `npm run build`
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689c8be65ce88323a1ed1dce86c96bcb