### PR TITLE
fix: allow direct access to logo asset

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -38,6 +38,6 @@ export function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    '/((?!api|_next/static|_next/image|favicon.ico).*)',
+    '/((?!api|_next/static|_next/image|favicon.ico|c-secur360-logo.png).*)',
   ],
 }


### PR DESCRIPTION
## Summary
- exclude `c-secur360-logo.png` from tenant rewrite middleware

## Testing
- `npm test`
- `curl -I http://localhost:3000/c-secur360-logo.png`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689c8bf2ad0083238be7453b8e654b5e