### PR TITLE
test: fix env mock for sanitizeFormData

### DIFF
--- a/app/api/ast/route.test.ts
+++ b/app/api/ast/route.test.ts
@@ -8,8 +8,11 @@ vi.mock('next/server', () => ({
 vi.mock('next-auth/jwt', () => ({ getToken: vi.fn() }))
 vi.mock('@/lib/prisma', () => ({ prisma: {} }))
 vi.mock('@/lib/env', () => ({
-  SERVER_ENV: { NEXTAUTH_SECRET: 'test' },
-  PUBLIC_ENV: {}
+  PUBLIC_ENV: {},
+  NODE_ENV: 'test',
+  WEATHER_API_KEY: '',
+  NEXTAUTH_SECRET: '',
+  BASE_URL: ''
 }))
 
 import { sanitizeFormData } from './utils'


### PR DESCRIPTION
## Summary
- expand env mock in sanitizeFormData tests to include required keys

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c97e7650883239af079ec07c3f5f8