### PR TITLE
refactor: use serverEnv for NextAuth

### DIFF
--- a/app/api/[tenant]/ast/[id]/route.ts
+++ b/app/api/[tenant]/ast/[id]/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { prisma } from '@/lib/prisma'
-import { SERVER_ENV } from '@/lib/env'
+import { serverEnv } from '@/lib/env'
 
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
 
 async function ensureUser(request: NextRequest, tenantSubdomain: string) {
-  const token = await getToken({ req: request, secret: SERVER_ENV.NEXTAUTH_SECRET })
+  const token = await getToken({ req: request, secret: serverEnv.NEXTAUTH_SECRET })
   if (!token?.sub) {
     return { error: NextResponse.json({ error: 'Authentication required' }, { status: 401 }) }
   }

--- a/app/api/[tenant]/ast/route.test.ts
+++ b/app/api/[tenant]/ast/route.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/lib/prisma', () => ({
 }))
 
 vi.mock('@/lib/env', () => ({
-  SERVER_ENV: { NEXTAUTH_SECRET: 'test' },
+  serverEnv: { NEXTAUTH_SECRET: 'test' },
   PUBLIC_ENV: {}
 }))
 

--- a/app/api/[tenant]/ast/route.ts
+++ b/app/api/[tenant]/ast/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { prisma } from '@/lib/prisma'
-import { SERVER_ENV } from '@/lib/env'
+import { serverEnv } from '@/lib/env'
 import { z } from 'zod'
 
 export const dynamic = 'force-dynamic'
@@ -12,7 +12,7 @@ const bodySchema = z.object({
 })
 
 async function ensureUser(request: NextRequest, tenantSubdomain: string) {
-  const token = await getToken({ req: request, secret: SERVER_ENV.NEXTAUTH_SECRET })
+  const token = await getToken({ req: request, secret: serverEnv.NEXTAUTH_SECRET })
   if (!token?.sub) {
     return { error: NextResponse.json({ error: 'Authentication required' }, { status: 401 }) }
   }

--- a/app/api/[tenant]/ast/save/route.ts
+++ b/app/api/[tenant]/ast/save/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { prisma } from '@/lib/prisma'
-import { SERVER_ENV } from '@/lib/env'
+import { serverEnv } from '@/lib/env'
 
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
 
 async function ensureUser(request: NextRequest, tenantSubdomain: string) {
-  const token = await getToken({ req: request, secret: SERVER_ENV.NEXTAUTH_SECRET })
+  const token = await getToken({ req: request, secret: serverEnv.NEXTAUTH_SECRET })
   if (!token?.sub) {
     return { error: NextResponse.json({ error: 'Authentication required' }, { status: 401 }) }
   }

--- a/app/api/ast/route.test.ts
+++ b/app/api/ast/route.test.ts
@@ -12,7 +12,8 @@ vi.mock('@/lib/env', () => ({
   NODE_ENV: 'test',
   WEATHER_API_KEY: '',
   NEXTAUTH_SECRET: '',
-  BASE_URL: ''
+  BASE_URL: '',
+  serverEnv: { NEXTAUTH_SECRET: '' }
 }))
 
 import { sanitizeFormData } from './utils'

--- a/app/api/ast/route.ts
+++ b/app/api/ast/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { prisma } from '@/lib/prisma'
 import { z } from 'zod'
-import { SERVER_ENV } from '@/lib/env'
+import { serverEnv } from '@/lib/env'
 import { sanitizeFormData } from './utils'
 
 export const dynamic = 'force-dynamic'
@@ -47,7 +47,7 @@ const requestSchema = z.object({
 
 export async function POST(request: NextRequest) {
   try {
-    const token = await getToken({ req: request, secret: SERVER_ENV.NEXTAUTH_SECRET })
+    const token = await getToken({ req: request, secret: serverEnv.NEXTAUTH_SECRET })
     const userId = token?.sub
     if (!userId) {
       return NextResponse.json(
@@ -116,7 +116,7 @@ export async function POST(request: NextRequest) {
 
 export async function GET(request: NextRequest) {
   try {
-    const token = await getToken({ req: request, secret: SERVER_ENV.NEXTAUTH_SECRET })
+    const token = await getToken({ req: request, secret: serverEnv.NEXTAUTH_SECRET })
     if (!token?.sub) {
       return NextResponse.json(
         { error: 'Authentication required' },

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -81,6 +81,9 @@ export const SERVER_ENV: ServerEnv = skipValidation
   ? ({ BASE_URL: 'http://localhost:3000', ...process.env } as unknown as ServerEnv)
   : parseServerEnv();
 
+// Temporary alias while migrating to `serverEnv`
+export const serverEnv: ServerEnv = SERVER_ENV;
+
 export const {
   DATABASE_URL,
   SUPABASE_SERVICE_ROLE_KEY,
@@ -89,5 +92,5 @@ export const {
   WEATHER_API_KEY,
   BASE_URL,
   NODE_ENV,
-} = SERVER_ENV;
+} = serverEnv;
 


### PR DESCRIPTION
## Summary
- expose `serverEnv` alias in env config
- use `serverEnv.NEXTAUTH_SECRET` when decoding JWTs in AST API routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c9f3479548323b30a5e21927b5dec