### PR TITLE
feat: add weather proxy api

### DIFF
--- a/app/api/weather/route.ts
+++ b/app/api/weather/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { SERVER_ENV } from '@/lib/env';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const lat = searchParams.get('lat');
+  const lon = searchParams.get('lon');
+
+  if (!lat || !lon) {
+    return NextResponse.json({ error: 'Missing lat or lon' }, { status: 400 });
+  }
+
+  try {
+    const apiKey = SERVER_ENV.WEATHER_API_KEY;
+    const res = await fetch(
+      `https://api.openweathermap.org/data/3.0/onecall?lat=${lat}&lon=${lon}&units=metric&appid=${apiKey}`
+    );
+
+    if (!res.ok) {
+      return NextResponse.json({ error: 'Failed to fetch weather data' }, { status: res.status });
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to fetch weather data' }, { status: 500 });
+  }
+}

--- a/hooks/useWeatherData.ts
+++ b/hooks/useWeatherData.ts
@@ -1,6 +1,6 @@
 // hooks/useWeatherData.ts
 import { useState, useEffect } from 'react';
-import { getWeatherData } from '@/lib/weatherApi';
+import { getWeatherData } from '@/lib/weatherApi'; // Utilise la route /api/weather
 
 export interface WeatherData {
   temperature: number;
@@ -46,12 +46,12 @@ export const useWeatherData = (coordinates: Coordinates) => {
     setError(null);
     
     try {
-      const weatherData = await getWeatherData(coordinates.lat, coordinates.lng);
-      setWeather(weatherData);
+        const fetchedWeather = await getWeatherData(coordinates.lat, coordinates.lng);
+        setWeather(fetchedWeather);
 
-      // Générer des alertes basées sur les conditions
-      const generatedAlerts = generateWeatherAlerts(weatherData);
-      setAlerts(generatedAlerts);
+        // Générer des alertes basées sur les conditions
+        const generatedAlerts = generateWeatherAlerts(fetchedWeather);
+        setAlerts(generatedAlerts);
 
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Erreur lors de la récupération des données météo';

--- a/lib/weatherApi.ts
+++ b/lib/weatherApi.ts
@@ -1,7 +1,6 @@
 import type { WeatherData } from '../hooks/useWeatherData';
-import { SERVER_ENV } from '@/lib/env';
+// Consomme l'API interne /api/weather qui protège la clé OpenWeather
 
-const API_BASE = 'https://api.openweathermap.org/data/3.0/onecall';
 const DEFAULT_TIMEOUT = 5000;
 
 const degToCompass = (deg: number): string => {
@@ -10,17 +9,13 @@ const degToCompass = (deg: number): string => {
 };
 
 export async function getWeatherData(lat: number, lng: number): Promise<WeatherData> {
-  const apiKey = SERVER_ENV.WEATHER_API_KEY;
-  if (!apiKey) {
-    throw new Error('WEATHER_API_KEY is not defined');
-  }
-
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT);
 
   try {
-    const url = `${API_BASE}?lat=${lat}&lon=${lng}&units=metric&appid=${apiKey}`;
-    const response = await fetch(url, { signal: controller.signal });
+    const response = await fetch(`/api/weather?lat=${lat}&lon=${lng}`, {
+      signal: controller.signal,
+    });
 
     if (!response.ok) {
       throw new Error(`Weather API error: ${response.status}`);


### PR DESCRIPTION
## Summary
- add `/api/weather` route that proxies OpenWeather using server env key
- fetch weather data through new API from client utilities
- update weather hook to use API proxy

## Testing
- `npm test`
- `npm run lint` *(fails: requires ESLint config)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c9f355c60832381edd448dfe39420