### PR TITLE
chore: enforce server-only in weather API

### DIFF
--- a/lib/weatherApi.ts
+++ b/lib/weatherApi.ts
@@ -1,3 +1,4 @@
+import 'server-only';
 import type { WeatherData } from '../hooks/useWeatherData';
 // Consomme l'API interne /api/weather qui protège la clé OpenWeather
 


### PR DESCRIPTION
## Summary
- enforce server-only context for weather API

## Testing
- `npm test`
- `npm run lint` *(fails: interactive eslint prompt)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cb9c24b088323b25750134fb9f08d