### PR TITLE
chore: mark server-only modules and configure tests

### DIFF
--- a/app/[tenant]/ast/[id]/page.tsx
+++ b/app/[tenant]/ast/[id]/page.tsx
@@ -1,3 +1,4 @@
+import 'server-only'
 import { prisma } from '@/lib/prisma'
 import { notFound } from 'next/navigation'
 import Link from 'next/link'

--- a/app/api/[tenant]/ast/[id]/route.ts
+++ b/app/api/[tenant]/ast/[id]/route.ts
@@ -1,3 +1,4 @@
+import 'server-only'
 import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { prisma } from '@/lib/prisma'

--- a/app/api/[tenant]/ast/route.ts
+++ b/app/api/[tenant]/ast/route.ts
@@ -1,3 +1,4 @@
+import 'server-only'
 import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { prisma } from '@/lib/prisma'

--- a/app/api/[tenant]/ast/save/route.ts
+++ b/app/api/[tenant]/ast/save/route.ts
@@ -1,3 +1,4 @@
+import 'server-only'
 import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { prisma } from '@/lib/prisma'

--- a/app/api/ast/route.ts
+++ b/app/api/ast/route.ts
@@ -1,3 +1,4 @@
+import 'server-only'
 import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { prisma } from '@/lib/prisma'

--- a/app/api/ast/utils.ts
+++ b/app/api/ast/utils.ts
@@ -1,3 +1,4 @@
+import 'server-only'
 import sanitizeHtml from 'sanitize-html'
 
 export function sanitizeFormData<T>(data: T): T {

--- a/app/api/db/init/route.ts
+++ b/app/api/db/init/route.ts
@@ -1,3 +1,4 @@
+import 'server-only'
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 

--- a/app/api/weather/route.ts
+++ b/app/api/weather/route.ts
@@ -1,3 +1,4 @@
+import 'server-only';
 import { NextRequest, NextResponse } from 'next/server';
 import { SERVER_ENV } from '@/lib/env';
 

--- a/app/utils/documentGeneration.ts
+++ b/app/utils/documentGeneration.ts
@@ -1,5 +1,6 @@
 // app/utils/documentGeneration.ts - Système de génération de documents
 
+import 'server-only';
 import { AST, ASTStatus } from '../types/ast';
 import { ComplianceReport } from './compliance';
 import { RiskLevel } from '../types/index';

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,3 +1,4 @@
+import 'server-only'
 import { PrismaClient } from '@prisma/client'
 import { SERVER_ENV } from '@/lib/env'
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,3 +1,4 @@
+import 'server-only'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18",
         "sanitize-html": "^2.17.0",
+        "server-only": "^0.0.1",
         "tailwind-merge": "^2.2.0",
         "tailwindcss": "^3.3.0",
         "zod": "^3.25.76",
@@ -7130,6 +7131,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18",
     "sanitize-html": "^2.17.0",
+    "server-only": "^0.0.1",
     "tailwind-merge": "^2.2.0",
     "tailwindcss": "^3.3.0",
     "zod": "^3.25.76",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    setupFiles: ['./vitest.setup.ts'],
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,3 @@
+import { vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));


### PR DESCRIPTION
## Summary
- add `server-only` marker to server-side modules
- stub `server-only` during tests with vitest setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb9c3962c83238fec76eefc8bf85a