### PR TITLE
Use client env for default tenant in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,7 @@
 import 'server-only'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
+import { clientEnv } from '@/lib/env.client'
 
 export function middleware(request: NextRequest) {
   const url = request.nextUrl.clone()
@@ -15,7 +16,7 @@ export function middleware(request: NextRequest) {
     .filter(Boolean)
 
   const defaultTenant =
-    process.env.NEXT_PUBLIC_DEFAULT_TENANT || validTenants[0] || 'demo'
+    clientEnv.NEXT_PUBLIC_DEFAULT_TENANT || validTenants[0] || 'demo'
 
   // Extraire le sous-domaine sans le port
   const subdomain = hostname.split('.')[0]


### PR DESCRIPTION
## Summary
- import clientEnv into middleware
- read default tenant from client-side env

## Testing
- `npm test`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e0c8197388323a90587cbf41ac783