### PR TITLE
feat: use env app name for metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import './globals.css'
 import RootLayoutClient from './RootLayoutClient'
+import { NEXT_PUBLIC_APP_NAME } from '@/lib/env.client'
 const inter = Inter({ subsets: ['latin'] })
 
 // ✅ VIEWPORT SÉPARÉ (obligatoire Next.js 14+)
@@ -13,8 +14,11 @@ export const viewport = {
 
 // ✅ METADATA SANS VIEWPORT
 export const metadata: Metadata = {
-  title: 'C-Secur360 - Analyse Sécuritaire de Tâches',
-  description: 'Application d\'analyse sécuritaire de tâches pour MDL',
+  title: {
+    default: NEXT_PUBLIC_APP_NAME,
+    template: `%s - ${NEXT_PUBLIC_APP_NAME}`,
+  },
+  description: "Application d'analyse sécuritaire de tâches pour MDL",
   manifest: '/manifest.json',
   themeColor: '#3498db',
 }


### PR DESCRIPTION
## Summary
- use `NEXT_PUBLIC_APP_NAME` to drive default document title

## Testing
- `npm test`
- `npm run lint` (fails: react/no-unescaped-entities and more)
- `npm run build` (fails: react/no-unescaped-entities and more)


------
https://chatgpt.com/codex/tasks/task_e_689e0c83689083239d5fbef00a9ed852