### PR TITLE
feat: add Supabase admin client

### DIFF
--- a/lib/env.server.ts
+++ b/lib/env.server.ts
@@ -5,6 +5,7 @@ const skipValidation = Boolean(process.env.SKIP_ENV_VALIDATION)
 const serverSchema = z.object({
   DATABASE_URL: z.string().url(),
   SUPABASE_SERVICE_ROLE_KEY: z.string(),
+  NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
   NEXTAUTH_SECRET: z.string(),
   NEXTAUTH_URL: z.string().url(),
   WEATHER_API_KEY: z.string(),
@@ -35,6 +36,7 @@ export const serverEnv: ServerEnv = skipValidation
 export const {
   DATABASE_URL,
   SUPABASE_SERVICE_ROLE_KEY,
+  NEXT_PUBLIC_SUPABASE_URL,
   NEXTAUTH_SECRET,
   NEXTAUTH_URL,
   WEATHER_API_KEY,

--- a/lib/supabaseAdmin.ts
+++ b/lib/supabaseAdmin.ts
@@ -1,0 +1,7 @@
+import 'server-only'
+import { createClient } from '@supabase/supabase-js'
+import { SUPABASE_SERVICE_ROLE_KEY, NEXT_PUBLIC_SUPABASE_URL } from '@/lib/env.server'
+
+export const supabaseAdmin = createClient(NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+
+export default supabaseAdmin


### PR DESCRIPTION
## Summary
- add server-only Supabase admin client
- expose NEXT_PUBLIC_SUPABASE_URL on server env

## Testing
- `npm test`
- `npm run lint` *(fails: react/no-unescaped-entities and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689e0c824b708323aa5f917f354b560f