### PR TITLE
Encode HTML entities for apostrophes and quotes

### DIFF
--- a/app/[tenant]/ast/[id]/page.tsx
+++ b/app/[tenant]/ast/[id]/page.tsx
@@ -87,7 +87,7 @@ export default async function ASTDetailPage({ params }: ASTDetailPageProps) {
                 <p className="text-white">{ast.clientRep || 'N/A'}</p>
               </div>
               <div>
-                <p className="text-slate-400">Numéro d'urgence</p>
+                <p className="text-slate-400">Numéro d&apos;urgence</p>
                 <p className="text-white">{ast.emergencyNumber || 'N/A'}</p>
               </div>
               <div>
@@ -104,7 +104,7 @@ export default async function ASTDetailPage({ params }: ASTDetailPageProps) {
           {/* Discussion équipe */}
           {teamDiscussion && teamDiscussion.length > 0 && (
             <div className="bg-gradient-to-br from-slate-800/50 to-slate-900/50 backdrop-blur-xl border border-slate-700/50 rounded-xl p-6">
-              <h2 className="text-xl font-bold text-white mb-4">💬 Discussion avec l'équipe</h2>
+              <h2 className="text-xl font-bold text-white mb-4">💬 Discussion avec l&apos;équipe</h2>
               <div className="space-y-2">
                 {teamDiscussion.map((item, index) => (
                   <div key={index} className="flex items-center space-x-2">
@@ -122,7 +122,7 @@ export default async function ASTDetailPage({ params }: ASTDetailPageProps) {
               <h2 className="text-xl font-bold text-white mb-4">⚡ Isolation Électrique</h2>
               {isolation.point && (
                 <div className="mb-4">
-                  <p className="text-slate-400 text-sm">Point d'isolement</p>
+                  <p className="text-slate-400 text-sm">Point d&apos;isolement</p>
                   <p className="text-white">{isolation.point}</p>
                 </div>
               )}

--- a/app/[tenant]/near-miss/page.tsx
+++ b/app/[tenant]/near-miss/page.tsx
@@ -20,7 +20,7 @@ export default function NearMissPage({ params }: NearMissPageProps) {
             </Link>
             <div>
               <h1 className="text-2xl font-bold text-white">⚠️ Passé proche</h1>
-              <p className="text-slate-400 text-sm">Signalement d'événements</p>
+              <p className="text-slate-400 text-sm">Signalement d&apos;événements</p>
             </div>
           </div>
         </div>
@@ -32,7 +32,7 @@ export default function NearMissPage({ params }: NearMissPageProps) {
           <div className="text-6xl mb-4">⚠️</div>
           <h2 className="text-2xl font-bold text-white mb-2">Module Passé proche</h2>
           <p className="text-slate-400 mb-6">Cette fonctionnalité sera disponible prochainement</p>
-          <p className="text-slate-300 text-sm">En attendant, vous pouvez signaler les événements via l'onglet "Passé proche" dans le formulaire AST.</p>
+          <p className="text-slate-300 text-sm">En attendant, vous pouvez signaler les événements via l&apos;onglet &quot;Passé proche&quot; dans le formulaire AST.</p>
         </div>
       </div>
     </div>

--- a/components/steps/Step4Permits/ConfinedSpace/AtmosphericTesting.tsx
+++ b/components/steps/Step4Permits/ConfinedSpace/AtmosphericTesting.tsx
@@ -97,13 +97,13 @@ const translations = {
     multiLevelTesting: "Tests Multi-Niveaux Obligatoires",
     deviceCalibration: "Calibration Équipement de Mesure",
     addReading: "Ajouter Mesure",
-    level: "Niveau dans l'espace",
+    level: "Niveau dans l&apos;espace",
     topLevel: "Niveau supérieur",
     middleLevel: "Niveau moyen", 
     bottomLevel: "Niveau inférieur",
     oxygen: "Oxygène (O₂)",
     lel: "Limite explosive (LEL)",
-    h2s: "Sulfure d'hydrogène (H₂S)",
+    h2s: "Sulfure d&apos;hydrogène (H₂S)",
     co: "Monoxyde de carbone (CO)",
     temperature: "Température",
     humidity: "Humidité",
@@ -688,7 +688,7 @@ const AtmosphericTesting: React.FC<ConfinedSpaceComponentProps> = ({
               flex: 1
             }}
           >
-            📊 <strong>TESTS MULTI-NIVEAUX</strong> : Tests atmosphériques effectués aux niveaux supérieur, moyen et inférieur de l'espace clos *
+            📊 <strong>TESTS MULTI-NIVEAUX</strong> : Tests atmosphériques effectués aux niveaux supérieur, moyen et inférieur de l&apos;espace clos *
           </label>
         </div>
         
@@ -723,7 +723,7 @@ const AtmosphericTesting: React.FC<ConfinedSpaceComponentProps> = ({
               flex: 1
             }}
           >
-            ✅ <strong>STABILITÉ ATMOSPHÉRIQUE</strong> : Je confirme que l'atmosphère est stable et conforme aux limites de {safeRegulations.authority} *
+            ✅ <strong>STABILITÉ ATMOSPHÉRIQUE</strong> : Je confirme que l&apos;atmosphère est stable et conforme aux limites de {safeRegulations.authority} *
           </label>
         </div>
       </div>

--- a/components/steps/Step4Permits/ConfinedSpace/EntryRegistry.tsx
+++ b/components/steps/Step4Permits/ConfinedSpace/EntryRegistry.tsx
@@ -866,7 +866,7 @@ const EntryRegistry: React.FC<ConfinedSpaceComponentProps> = ({
             margin: 0,
             fontStyle: 'italic'
           }}>
-            ⏰ <strong>Durée maximale</strong> : {safeRegulations.permit_validity_hours}h consécutives maximum par personne dans l'espace clos.
+            ⏰ <strong>Durée maximale</strong> : {safeRegulations.permit_validity_hours}h consécutives maximum par personne dans l&apos;espace clos.
           </p>
         </div>
         
@@ -913,7 +913,7 @@ const EntryRegistry: React.FC<ConfinedSpaceComponentProps> = ({
                 flex: 1
               }}
             >
-              👁️ <strong>SURVEILLANT PRÉSENT</strong> : Je confirme qu'un surveillant qualifié est présent et maintient une surveillance constante *
+              👁️ <strong>SURVEILLANT PRÉSENT</strong> : Je confirme qu&apos;un surveillant qualifié est présent et maintient une surveillance constante *
             </label>
           </div>
           
@@ -984,7 +984,7 @@ const EntryRegistry: React.FC<ConfinedSpaceComponentProps> = ({
                 flex: 1
               }}
             >
-              🚑 <strong>SAUVETAGE PRÊT</strong> : Équipe et équipement de sauvetage d'urgence prêts à intervenir immédiatement *
+              🚑 <strong>SAUVETAGE PRÊT</strong> : Équipe et équipement de sauvetage d&apos;urgence prêts à intervenir immédiatement *
             </label>
           </div>
         </div>
@@ -1014,7 +1014,7 @@ const EntryRegistry: React.FC<ConfinedSpaceComponentProps> = ({
                   🚨 {t.emergencyEvacuationInitiated}
                 </h3>
                 <p style={{ color: '#fca5a5', fontSize: isMobile ? '14px' : '16px' }}>
-                  Procédures d'urgence activées - Contacts d'urgence notifiés
+                  Procédures d&apos;urgence activées - Contacts d&apos;urgence notifiés
                 </p>
               </div>
             </div>
@@ -1270,7 +1270,7 @@ const EntryRegistry: React.FC<ConfinedSpaceComponentProps> = ({
                 />
               </div>
               <div>
-                <label style={styles.label}>Contact d'urgence - Nom</label>
+                <label style={styles.label}>Contact d&apos;urgence - Nom</label>
                 <input
                   type="text"
                   placeholder="Ex: Marie Dupont"
@@ -1280,7 +1280,7 @@ const EntryRegistry: React.FC<ConfinedSpaceComponentProps> = ({
                 />
               </div>
               <div>
-                <label style={styles.label}>Contact d'urgence - Téléphone</label>
+                <label style={styles.label}>Contact d&apos;urgence - Téléphone</label>
                 <input
                   type="tel"
                   placeholder="Ex: (514) 987-6543"
@@ -1527,7 +1527,7 @@ const EntryRegistry: React.FC<ConfinedSpaceComponentProps> = ({
                     fontSize: '13px',
                     color: '#d1d5db'
                   }}>
-                    <div>🚑 <strong>Contact d'urgence:</strong> {person.emergencyContact?.name || 'N/A'} - {person.emergencyContact?.phone || 'N/A'}</div>
+                    <div>🚑 <strong>Contact d&apos;urgence:</strong> {person.emergencyContact?.name || 'N/A'} - {person.emergencyContact?.phone || 'N/A'}</div>
                   </div>
                 </div>
               );
@@ -1590,7 +1590,7 @@ const EntryRegistry: React.FC<ConfinedSpaceComponentProps> = ({
                 <option value="radio">📻 Radio</option>
                 <option value="visual">👁️ Visuel</option>
                 <option value="hand_signal">✋ Signal manuel</option>
-                <option value="emergency_signal">🚨 Signal d'urgence</option>
+                <option value="emergency_signal">🚨 Signal d&apos;urgence</option>
               </select>
             </div>
             <div>

--- a/components/steps/Step4Permits/ConfinedSpace/RescuePlan.tsx
+++ b/components/steps/Step4Permits/ConfinedSpace/RescuePlan.tsx
@@ -754,7 +754,7 @@ const RescuePlan: React.FC<ConfinedSpaceComponentProps> = ({
             gap: '12px'
           }}>
             <Users style={{ width: '24px', height: '24px', color: '#fecaca' }} />
-            🎓 Certification Réglementaire de l'Équipe de Sauvetage
+            🎓 Certification Réglementaire de l&apos;Équipe de Sauvetage
           </h4>
           
           <div style={{ 
@@ -771,7 +771,7 @@ const RescuePlan: React.FC<ConfinedSpaceComponentProps> = ({
               margin: '0 0 12px 0',
               fontWeight: '600'
             }}>
-              🎓 <strong>CERTIFICATION OBLIGATOIRE</strong> : L'équipe de sauvetage doit posséder les certifications réglementaires CSA Z1006-2023 et formations de premiers soins niveau 2.
+              🎓 <strong>CERTIFICATION OBLIGATOIRE</strong> : L&apos;équipe de sauvetage doit posséder les certifications réglementaires CSA Z1006-2023 et formations de premiers soins niveau 2.
             </p>
             <p style={{ 
               color: '#fca5a5', 
@@ -791,7 +791,7 @@ const RescuePlan: React.FC<ConfinedSpaceComponentProps> = ({
               fontWeight: '700',
               marginBottom: '16px'
             }}>
-              Certifications Obligatoires de l'Équipe
+              Certifications Obligatoires de l&apos;Équipe
             </h5>
             
             <div style={styles.grid2}>
@@ -1020,13 +1020,13 @@ const RescuePlan: React.FC<ConfinedSpaceComponentProps> = ({
                 flex: 1
               }}
             >
-              📅 <strong>EXERCICE ANNUEL OBLIGATOIRE</strong> : Test d'efficacité du plan de sauvetage effectué dans les 12 derniers mois *
+              📅 <strong>EXERCICE ANNUEL OBLIGATOIRE</strong> : Test d&apos;efficacité du plan de sauvetage effectué dans les 12 derniers mois *
             </label>
           </div>
           
           {rescueData.annual_drill_required && (
             <div style={{ marginTop: '16px' }}>
-              <label style={{ ...styles.label, color: '#fca5a5' }}>Date dernier test d'efficacité *</label>
+              <label style={{ ...styles.label, color: '#fca5a5' }}>Date dernier test d&apos;efficacité *</label>
               <input
                 type="date"
                 value={rescueData.last_effectiveness_test || ''}


### PR DESCRIPTION
## Summary
- escape apostrophes in AST detail labels
- encode apostrophes and quotes in near-miss and confined-space permit components
- ensure JSX text nodes consistently use HTML entities for apostrophes/quotes

## Testing
- `npm test`
- `npm run lint` *(fails: Component definition is missing display name and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689e201f0e608323942878a5e3650208