### PR TITLE
refactor: use next/image for images

### DIFF
--- a/app/[tenant]/dashboard/ManagerDashboard.tsx
+++ b/app/[tenant]/dashboard/ManagerDashboard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import Image from 'next/image'
 import { useState, useEffect } from 'react'
 import { t } from '@/utils/translations'
 import LanguageSwitcher from './LanguageSwitcher'
@@ -586,13 +587,15 @@ export default function ManagerDashboard({ tenant = { id: '1', subdomain: 'demo'
                     position: 'relative',
                     zIndex: 1
                   }}>
-                    <img 
-                      src="/c-secur360-logo.png" 
+                    <Image
+                      src="/c-secur360-logo.png"
                       alt="C-Secur360"
+                      width={200}
+                      height={200}
                       className="logo-glow"
-                      style={{ 
-                        width: '200px', 
-                        height: '200px', 
+                      style={{
+                        width: '200px',
+                        height: '200px',
                         objectFit: 'contain'
                       }}
                       onError={(e) => {

--- a/components/ASTForm.tsx
+++ b/components/ASTForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import Image from 'next/image';
 import {
   FileText, ArrowLeft, ArrowRight, Save, Eye, Download, CheckCircle,
   AlertTriangle, Clock, Shield, Users, MapPin, Calendar, Building,
@@ -487,11 +488,13 @@ export default function ASTForm<T extends ASTFormData = ASTFormData>({
           position: 'relative',
           zIndex: 1
         }}>
-          <img 
-            src="/c-secur360-logo.png" 
+          <Image
+            src="/c-secur360-logo.png"
             alt="C-Secur360"
+            width={isMobile ? 50 : 200}
+            height={isMobile ? 50 : 200}
             className="logo-glow"
-            style={{ 
+            style={{
               width: isMobile ? '50px' : '200px',
               height: isMobile ? '50px' : '200px',
               objectFit: 'contain',
@@ -499,8 +502,8 @@ export default function ASTForm<T extends ASTFormData = ASTFormData>({
             }}
             onError={(e) => {
               console.log('❌ Erreur chargement logo:', e);
-              e.currentTarget.style.display = 'none';
-              const fallback = e.currentTarget.nextElementSibling as HTMLElement;
+              (e.currentTarget as HTMLImageElement).style.display = 'none';
+              const fallback = (e.currentTarget.nextElementSibling as HTMLElement);
               if (fallback) fallback.style.display = 'flex';
             }}
           />

--- a/components/steps/Step1ProjectInfo.tsx
+++ b/components/steps/Step1ProjectInfo.tsx
@@ -2,6 +2,7 @@
 'use client';
 
 import React, { useState, useRef, useCallback, useEffect, useMemo } from 'react';
+import Image from 'next/image';
 import {
   FileText, Building, Phone, MapPin, Calendar, Clock, Users, User, Briefcase,
   Copy, Check, AlertTriangle, Camera, Upload, X, Lock, Zap, Settings, Wrench,
@@ -1032,7 +1033,19 @@ function Step1ProjectInfo({ formData, onDataChange, language, tenant, errors = {
           <div className="carousel-track" style={{ transform: `translateX(-${currentIndex * 100}%)` }}>
             {photos.map((photo: LockoutPhoto, index: number) => (
               <div key={photo.id} className="carousel-slide">
-                <img src={photo.url} alt={photo.caption} />
+                <Image
+                  src={photo.url}
+                  alt={photo.caption}
+                  width={800}
+                  height={600}
+                  style={{
+                    maxWidth: '100%',
+                    maxHeight: '100%',
+                    objectFit: 'contain',
+                    borderRadius: '8px',
+                  }}
+                  unoptimized
+                />
                 <div className="photo-info">
                   <div className="photo-caption">
                     <h4>{getCategoryLabel(photo.category)}</h4>

--- a/components/steps/Step4Permits/ConfinedSpace/PermitManager.tsx
+++ b/components/steps/Step4Permits/ConfinedSpace/PermitManager.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from 'react';
+import Image from 'next/image';
 import { 
   FileText, Database, QrCode, Printer, Mail, Share, Download, 
   Save, CheckCircle, AlertTriangle, Clock, Shield, Users, 
@@ -1170,14 +1171,17 @@ const PermitManager: React.FC<ConfinedSpaceComponentProps> = ({
               borderRadius: '12px',
               marginBottom: '16px'
             }}>
-              <img 
-                src={qrCodeUrl} 
-                alt="QR Code du permis" 
-                style={{ 
-                  width: currentIsMobile ? '200px' : '250px', 
+              <Image
+                src={qrCodeUrl}
+                alt="QR Code du permis"
+                width={currentIsMobile ? 200 : 250}
+                height={currentIsMobile ? 200 : 250}
+                style={{
+                  width: currentIsMobile ? '200px' : '250px',
                   height: currentIsMobile ? '200px' : '250px',
                   display: 'block'
-                }} 
+                }}
+                unoptimized
               />
             </div>
             <p style={{ color: '#d1d5db', fontSize: '14px', lineHeight: 1.5 }}>

--- a/components/steps/Step4Permits/ConfinedSpace/SiteInformation.tsx
+++ b/components/steps/Step4Permits/ConfinedSpace/SiteInformation.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import React, { useState, useRef, useCallback } from 'react';
+import Image from 'next/image';
 import { 
   FileText, Building, Phone, MapPin, Calendar, Clock, Users, User, Briefcase, 
   AlertTriangle, Camera, Upload, X, Settings, Wrench, Droplets, 
@@ -1783,14 +1784,17 @@ const SiteInformation: React.FC<ConfinedSpaceComponentProps> = ({
                   overflow: 'hidden',
                   border: '1px solid #374151'
                 }}>
-                  <img 
-                    src={photo.url} 
+                  <Image
+                    src={photo.url}
                     alt={photo.caption}
+                    width={300}
+                    height={isMobile ? 120 : 150}
                     style={{
                       width: '100%',
                       height: isMobile ? '120px' : '150px',
                       objectFit: 'cover'
                     }}
+                    unoptimized
                   />
                   <div style={{
                     position: 'absolute',

--- a/components/steps/Step6Finalization.tsx
+++ b/components/steps/Step6Finalization.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useRef, useCallback, useMemo } from 'react';
+import Image from 'next/image';
 import {
   FileText, Database, QrCode, Printer,
   Save, CheckCircle, AlertTriangle, Clock, Shield, Users,
@@ -3092,17 +3093,19 @@ function Step6Finalization({
         <div className="ast-header">
           <div className="ast-header-content">
             <div className="ast-logo">
-              <img 
-                src="/c-secur360-logo.png" 
+              <Image
+                src="/c-secur360-logo.png"
                 alt="C-Secur360"
-                style={{ 
-                  width: isMobile ? '48px' : '64px', 
-                  height: isMobile ? '48px' : '64px', 
+                width={isMobile ? 48 : 64}
+                height={isMobile ? 48 : 64}
+                style={{
+                  width: isMobile ? '48px' : '64px',
+                  height: isMobile ? '48px' : '64px',
                   objectFit: 'contain',
                   filter: 'brightness(1.2) contrast(1.1)'
                 }}
                 onError={(e) => {
-                  e.currentTarget.style.display = 'none';
+                  (e.currentTarget as HTMLImageElement).style.display = 'none';
                   const fallback = e.currentTarget.nextElementSibling as HTMLElement;
                   if (fallback) fallback.style.display = 'flex';
                 }}

--- a/components/steps/Step6Finalization/SharingSection.tsx
+++ b/components/steps/Step6Finalization/SharingSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import Image from 'next/image';
 import { Share2, Mail, Smartphone, MessageSquare, Users, Hash, Share, QrCode } from 'lucide-react';
 import type { FinalizationData, ShareMethod, Translations } from '../Step6Finalization';
 
@@ -126,14 +127,17 @@ const SharingSection: React.FC<SharingSectionProps> = ({
               boxShadow: '0 8px 25px rgba(245, 158, 11, 0.3)',
             }}
           >
-            <img
+            <Image
               src={finalizationData.qrCodeUrl}
               alt="QR Code AST"
+              width={isMobile ? 180 : 220}
+              height={isMobile ? 180 : 220}
               style={{
                 width: isMobile ? '180px' : '220px',
                 height: isMobile ? '180px' : '220px',
                 display: 'block',
               }}
+              unoptimized
             />
           </div>
           <p


### PR DESCRIPTION
## Summary
- replace legacy `<img>` tags with Next.js `<Image>` components across dashboard and AST steps
- ensure `width`, `height`, and `alt` provided for each converted image

## Testing
- `npm test`
- `npm run lint` *(fails: react/no-unescaped-entities and other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e201f82ec8323a838ee3b2435cc3c