### PR TITLE
refactor: name exported utility constants

### DIFF
--- a/app/data/equipment/index.ts
+++ b/app/data/equipment/index.ts
@@ -290,7 +290,7 @@ export type {
 
 // =================== EXPORT PAR DÉFAUT ===================
 
-export default {
+const equipmentApi = {
   allEquipment,
   equipmentById,
   equipmentByCategory,
@@ -303,3 +303,5 @@ export default {
   getEquipmentRequiringAttention,
   validateAllEquipment
 };
+
+export default equipmentApi;

--- a/app/utils/compliance.ts
+++ b/app/utils/compliance.ts
@@ -553,10 +553,12 @@ export function generateTenantRecommendations(
   return recommendations;
 }
 
-export default {
+const complianceUtils = {
   checkASTCompliance,
   checkStandardCompliance,
   getTenantComplianceReport,
   generateTenantRecommendations,
   REGULATORY_STANDARDS_BY_REGION
 };
+
+export default complianceUtils;

--- a/app/utils/documentGeneration.ts
+++ b/app/utils/documentGeneration.ts
@@ -904,7 +904,7 @@ function generateNotificationId(): string {
 }
 
 // =================== EXPORTS ===================
-export default {
+const documentGenerationUtils = {
   sendNotification,
   sendASTNotification,
   sendComplianceNotification,
@@ -915,3 +915,5 @@ export default {
   NotificationPriority,
   ChannelType
 };
+
+export default documentGenerationUtils;

--- a/app/utils/notifications.ts
+++ b/app/utils/notifications.ts
@@ -313,9 +313,11 @@ export async function scheduleReminders(
   console.log('Programmation rappels:', { astsCount: asts.length, tenantId });
 }
 
-export default {
+const notificationUtils = {
   sendNotification,
   sendASTNotification,
   scheduleReminders,
   DEFAULT_NOTIFICATION_TEMPLATES
 };
+
+export default notificationUtils;

--- a/app/utils/riskCalculations.ts
+++ b/app/utils/riskCalculations.ts
@@ -620,7 +620,7 @@ export function calculateTenantRiskStatistics(tenantASTs: AST[]) {
   };
 }
 
-export default {
+const riskCalculations = {
   calculateBasicRisk,
   calculateRiskWithExposure,
   calculateResidualRisk,
@@ -630,3 +630,5 @@ export default {
   STANDARD_RISK_MATRIX,
   EXPOSURE_ADJUSTED_MATRIX
 };
+
+export default riskCalculations;

--- a/app/utils/translations.ts
+++ b/app/utils/translations.ts
@@ -799,7 +799,7 @@ export const useTranslation = () => {
   };
 };
 
-export default {
+const translationUtils = {
   TranslationService,
   translationService,
   t,
@@ -814,3 +814,5 @@ export default {
   TRANSLATIONS,
   DEFAULT_CONFIG
 };
+
+export default translationUtils;

--- a/hooks/useWeatherData.ts
+++ b/hooks/useWeatherData.ts
@@ -1,6 +1,6 @@
 // hooks/useWeatherData.ts
 import { useState, useEffect } from 'react';
-import { getWeatherData } from '@/lib/weatherApi'; // Utilise la route /api/weather
+import weatherApi from '@/lib/weatherApi'; // Utilise la route /api/weather
 
 export interface WeatherData {
   temperature: number;
@@ -46,7 +46,7 @@ export const useWeatherData = (coordinates: Coordinates) => {
     setError(null);
     
     try {
-        const fetchedWeather = await getWeatherData(coordinates.lat, coordinates.lng);
+        const fetchedWeather = await weatherApi.getWeatherData(coordinates.lat, coordinates.lng);
         setWeather(fetchedWeather);
 
         // Générer des alertes basées sur les conditions

--- a/lib/weatherApi.ts
+++ b/lib/weatherApi.ts
@@ -60,4 +60,6 @@ export async function getWeatherData(lat: number, lng: number): Promise<WeatherD
   }
 }
 
-export default { getWeatherData };
+const weatherApi = { getWeatherData };
+
+export default weatherApi;


### PR DESCRIPTION
## Summary
- give default-exported utilities descriptive constant names
- adjust weather hook to use weatherApi constant

## Testing
- `npm test`
- `npm run lint` *(fails: react/no-unescaped-entities, react/display-name, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689e2021590083239c7412c867e2c7e2