### PR TITLE
fix: include equipment dependency

### DIFF
--- a/app/utils/notifications.ts
+++ b/app/utils/notifications.ts
@@ -314,7 +314,6 @@ export async function scheduleReminders(
 }
 
 const notificationUtils = {
->>>>>>> main
   sendNotification,
   sendASTNotification,
   scheduleReminders,
@@ -322,4 +321,3 @@ const notificationUtils = {
 };
 
 export default notificationUtils;
->>>>>>> main

--- a/components/steps/Step2Equipment.tsx
+++ b/components/steps/Step2Equipment.tsx
@@ -794,7 +794,7 @@ const Step2Equipment: React.FC<Step2EquipmentProps> = ({
       return currentItem ? { ...translatedItem, required: currentItem.required } : translatedItem;
     });
     setEquipment(updatedEquipment);
-  }, [language]);
+  }, [language, equipment]);
 
   // =================== COMPOSANTS UTILITAIRES ===================
   


### PR DESCRIPTION
## Summary
- ensure equipment changes retrigger translation effect by including in dependency list
- remove leftover merge conflict markers in notification utilities to restore build

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e296550ec8323a625af39318c781b