### PR TITLE
Include handleGenerateQR in PermitManager dependencies

### DIFF
--- a/components/steps/Step4Permits/ConfinedSpace/PermitManager.tsx
+++ b/components/steps/Step4Permits/ConfinedSpace/PermitManager.tsx
@@ -642,7 +642,7 @@ const PermitManager: React.FC<ConfinedSpaceComponentProps> = ({
     if (permit.permit_number && !qrCodeUrl && safetyManager) {
       handleGenerateQR();
     }
-  }, [permit.permit_number, qrCodeUrl, safetyManager]);
+  }, [permit.permit_number, qrCodeUrl, safetyManager, handleGenerateQR]);
 
   useEffect(() => {
     if (searchQuery.length >= 2) {


### PR DESCRIPTION
## Summary
- ensure QR generation handler is part of PermitManager useEffect dependencies

## Testing
- `npm run build` *(fails: Parsing error in app/utils/notifications.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689e29692a3c83239557549d61080123