### PR TITLE
fix: stabilize atmospheric testing callbacks

### DIFF
--- a/components/steps/Step4Permits/ConfinedSpace/AtmosphericTesting.tsx
+++ b/components/steps/Step4Permits/ConfinedSpace/AtmosphericTesting.tsx
@@ -194,7 +194,7 @@ const AtmosphericTesting: React.FC<ConfinedSpaceComponentProps> = ({
       },
       lastUpdated: new Date().toISOString()
     }
-  ), [safetyManager?.currentPermit?.atmosphericTesting, safetyManager?.lastUpdateTime]);
+  ), [safetyManager?.currentPermit?.atmosphericTesting]);
 
   const atmosphericReadings = useMemo(
     () => atmosphericData.readings || [],
@@ -264,26 +264,29 @@ const AtmosphericTesting: React.FC<ConfinedSpaceComponentProps> = ({
   }, [updateAtmosphericData]);
 
   // =================== FONCTIONS UTILITAIRES ===================
-  const validateAtmosphericValue = (type: keyof AtmosphericLimits, value: number): 'safe' | 'warning' | 'danger' => {
-    const currentRegulations = regulations[selectedProvince];
-    if (!currentRegulations?.limits?.[type]) {
-      return 'safe'; // Fallback si pas de réglementation
-    }
-    
-    const limits = currentRegulations.limits[type];
-    
-    if (type === 'oxygen') {
-      const oxygenLimits = limits as AtmosphericLimits['oxygen'];
-      if (value <= oxygenLimits.critical_low || value >= oxygenLimits.critical_high) return 'danger';
-      if (value < oxygenLimits.min || value > oxygenLimits.max) return 'warning';
-    } else {
-      const gasLimits = limits as AtmosphericLimits['lel'] | AtmosphericLimits['h2s'] | AtmosphericLimits['co'];
-      if (value >= gasLimits.critical) return 'danger';
-      if (value > gasLimits.max) return 'warning';
-    }
-    
-    return 'safe';
-  };
+  const validateAtmosphericValue = useCallback(
+    (type: keyof AtmosphericLimits, value: number): 'safe' | 'warning' | 'danger' => {
+      const currentRegulations = regulations[selectedProvince];
+      if (!currentRegulations?.limits?.[type]) {
+        return 'safe'; // Fallback si pas de réglementation
+      }
+
+      const limits = currentRegulations.limits[type];
+
+      if (type === 'oxygen') {
+        const oxygenLimits = limits as AtmosphericLimits['oxygen'];
+        if (value <= oxygenLimits.critical_low || value >= oxygenLimits.critical_high) return 'danger';
+        if (value < oxygenLimits.min || value > oxygenLimits.max) return 'warning';
+      } else {
+        const gasLimits = limits as AtmosphericLimits['lel'] | AtmosphericLimits['h2s'] | AtmosphericLimits['co'];
+        if (value >= gasLimits.critical) return 'danger';
+        if (value > gasLimits.max) return 'warning';
+      }
+
+      return 'safe';
+    },
+    [regulations, selectedProvince]
+  );
 
   const formatTime = (seconds: number) => {
     const mins = Math.floor(seconds / 60);


### PR DESCRIPTION
## Summary
- remove unnecessary safetyManager dependency in atmospheric data memo
- wrap validateAtmosphericValue with useCallback for stable callbacks

## Testing
- `npm run build` *(fails: Parsing error: Merge conflict marker encountered in app/utils/notifications.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689e2967e8ac8323813fe9e08b8fb7d4