### PR TITLE
Include tenant in PDF generation dependencies

### DIFF
--- a/components/steps/Step6Finalization.tsx
+++ b/components/steps/Step6Finalization.tsx
@@ -1878,7 +1878,7 @@ function Step6Finalization({
       showNotificationToast(language === 'fr' ? 'Erreur génération PDF' : 'Error generating PDF', 'error');
       setIsGeneratingPDF(false);
     }
-  }, [extractCompleteASTData, getASTStatistics, getSectionValidation, finalizationData, onDataChange, language, t, showNotificationToast]);
+  }, [extractCompleteASTData, getASTStatistics, getSectionValidation, finalizationData, onDataChange, language, t, showNotificationToast, tenant]);
 
   /**
    * ✅ HANDLER PARTAGE AST MULTI-CANAUX SÉCURISÉ


### PR DESCRIPTION
## Summary
- add tenant to handleGeneratePDF useCallback dependencies

## Testing
- `npm run build` *(fails: Parsing error: Merge conflict marker encountered in ./app/utils/notifications.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689e296d66f88323b60742b988b117d1