### PR TITLE
fix: clean callback dependencies

### DIFF
--- a/components/steps/Step4Permits/ConfinedSpace/EntryRegistry.tsx
+++ b/components/steps/Step4Permits/ConfinedSpace/EntryRegistry.tsx
@@ -828,7 +828,7 @@ const EntryRegistry: React.FC<ConfinedSpaceComponentProps> = ({
     } else {
       alert(`✅ Communication vérifiée avec ${person.name}`);
     }
-  }, [communicationCheck, communicationLogs, personnelStatuses, entryLogs, getPersonById, getPersonnelStatus, updateEntryLogs]);
+  }, [communicationCheck, communicationLogs, personnelStatuses, getPersonById, getPersonnelStatus]);
 
   // =================== RENDU JSX PRINCIPAL ===================
   return (


### PR DESCRIPTION
## Summary
- remove unused `entryLogs` and `updateEntryLogs` from communication check callback dependencies

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e48a63250832380fd8a8e0b61e46f