### PR TITLE
refactor: stabilize personnel lookup

### DIFF
--- a/components/steps/Step4Permits/ConfinedSpace/EntryRegistry.tsx
+++ b/components/steps/Step4Permits/ConfinedSpace/EntryRegistry.tsx
@@ -336,9 +336,10 @@ const EntryRegistry: React.FC<ConfinedSpaceComponentProps> = ({
   }, [updateEntryRegistryData, entryRegistryData.entryLogs]);
 
   // =================== FONCTIONS UTILITAIRES ===================
-  const getCurrentPersonnelInside = () => {
-    return personnelStatuses.filter(status => status.current_status === 'inside');
-  };
+  const getCurrentPersonnelInside = React.useCallback(
+    () => personnelStatuses.filter(status => status.current_status === 'inside'),
+    [personnelStatuses]
+  );
 
   const getCurrentPersonnelOutside = () => {
     return personnelStatuses.filter(status => status.current_status === 'outside');


### PR DESCRIPTION
## Summary
- memoize getCurrentPersonnelInside to provide stable dependencies for hooks

## Testing
- `npm test`
- `npm run lint` (warnings)


------
https://chatgpt.com/codex/tasks/task_e_689e48a71f448323989172154e80506e