### PR TITLE
test: add default alt to Next Image mock

### DIFF
--- a/components/steps/Step1ProjectInfo.test.tsx
+++ b/components/steps/Step1ProjectInfo.test.tsx
@@ -8,7 +8,7 @@ import { vi, describe, it, expect } from 'vitest';
 vi.mock('next/image', () => ({
   default: (props: any) => {
     // eslint-disable-next-line @next/next/no-img-element
-    return <img {...props} />;
+    return <img alt="" {...props} />;
   },
 }));
 


### PR DESCRIPTION
## Summary
- add default alt attribute to Next Image mock in Step1ProjectInfo test

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689e74e93ed48323b644bbe9de861bbf