### PR TITLE
fix: include showNotification in permit manager search dependencies

### DIFF
--- a/components/steps/Step4Permits/ConfinedSpace/PermitManager.tsx
+++ b/components/steps/Step4Permits/ConfinedSpace/PermitManager.tsx
@@ -469,7 +469,7 @@ const PermitManager: React.FC<ConfinedSpaceComponentProps> = ({
     } finally {
       setIsSearching(false);
     }
-  }, [safetyManager, qrCodeUrl]);
+  }, [safetyManager, qrCodeUrl, showNotification]);
 
   // ✅ CORRECTION 3 : Handler chargement avec vérifications SafetyManager
   const handleLoadPermit = async (permitNumber: string) => {


### PR DESCRIPTION
## Summary
- include `showNotification` in `handleSearch` useCallback dependencies

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e74ece26c83239f58e1d62cdcc4d4